### PR TITLE
feat: add code to verify BFactory and BPool contracts on mumbai and polygon

### DIFF
--- a/contracts/verify-bfactory/ALL_IN_ONE.sol
+++ b/contracts/verify-bfactory/ALL_IN_ONE.sol
@@ -1,0 +1,784 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+/**
+ * @title IAuthorization
+ * @author Protofire
+ * @dev Interface to be implemented by any Authorization logic contract.
+ *
+ */
+interface IAuthorization {
+    /**
+     * @dev Sets `_permissions` as the new Permissions module.
+     *
+     * @param _permissions The address of the new Pemissions module.
+     */
+    function setPermissions(address _permissions) external returns (bool);
+
+    /**
+     * @dev Sets `_eurPriceFeed` as the new EUR Price feed module.
+     *
+     * @param _eurPriceFeed The address of the new EUR Price feed module.
+     */
+    function setEurPriceFeed(address _eurPriceFeed) external returns (bool);
+
+    /**
+     * @dev Sets `_operationsRegistry` as the new OperationsRegistry module.
+     *
+     * @param _operationsRegistry The address of the new OperationsRegistry module.
+     */
+    function setOperationsRegistry(address _operationsRegistry) external returns (bool);
+
+    /**
+     * @dev Sets `_tradingLimit` as the new traiding limit.
+     *
+     * @param _tradingLimit The value of the new traiding limit.
+     */
+    function setTradingLimint(uint256 _tradingLimit) external returns (bool);
+
+    /**
+     * @dev Determins if a user is allowed to perform an operation.
+     *
+     * @param _user msg.sender from function using Authorizable `onlyAuthorized` modifier.
+     * @param _asset address of the contract using Authorizable `onlyAuthorized` modifier.
+     * @param _operation msg.sig from function using Authorizable `onlyAuthorized` modifier.
+     * @param _data msg.data from function using Authorizable `onlyAuthorized` modifier.
+     * @return a boolean signaling the authorization.
+     */
+    function isAuthorized(
+        address _user,
+        address _asset,
+        bytes4 _operation,
+        bytes calldata _data
+    ) external returns (bool);
+}
+
+
+/**
+ * @title Authorizable
+ * @author Protofire
+ * @dev Contract module which provides an authorization mechanism.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyAuthorized`, which can be applied to your functions to restrict their use.
+ */
+abstract contract Authorizable is Context {
+    IAuthorization public authorization;
+
+    /**
+     * @dev Emitted when `authorization` address is setted.
+     */
+    event AuthorizationSetted(address indexed newAuthorization);
+
+    /**
+     * @dev Throws if called by any account which is not authorized to execute the transaction.
+     */
+    modifier onlyAuthorized() {
+        require(
+            authorization.isAuthorized(_msgSender(), address(this), msg.sig, _msgData()),
+            "Authorizable: not authorized"
+        );
+        _;
+    }
+
+    /**
+     * @dev Sets authorization.
+     *
+     */
+    function _setAuthorization(address authorization_) internal {
+        require(authorization_ != address(0), "Authorizable: authorization is the zero address");
+        authorization = IAuthorization(authorization_);
+        emit AuthorizationSetted(authorization_);
+    }
+}
+
+
+abstract contract BColor {
+    function getColor()
+        external virtual view
+        returns (bytes32);
+}
+
+contract BBronze is BColor {
+    function getColor()
+        external override view
+        returns (bytes32) {
+            return bytes32("BRONZE");
+        }
+}
+
+
+
+interface IERC20 {
+    function totalSupply() external view returns (uint);
+    function balanceOf(address whom) external view returns (uint);
+    function allowance(address src, address dst) external view returns (uint);
+
+    function approve(address dst, uint amt) external returns (bool);
+    function transfer(address dst, uint amt) external returns (bool);
+    function transferFrom(
+        address src, address dst, uint amt
+    ) external returns (bool);
+}
+
+
+/**
+ * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM
+ * instruction `delegatecall`. We refer to the second contract as the _implementation_ behind the proxy, and it has to
+ * be specified by overriding the virtual {_implementation} function.
+ *
+ * Additionally, delegation to the implementation can be triggered manually through the {_fallback} function, or to a
+ * different contract through the {_delegate} function.
+ *
+ * The success and return data of the delegated call will be returned back to the caller of the proxy.
+ */
+abstract contract Proxy {
+    /**
+     * @dev Delegates the current call to `implementation`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _delegate(address implementation) internal virtual {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    /**
+     * @dev This is a virtual function that should be overriden so it returns the address to which the fallback function
+     * and {_fallback} should delegate.
+     */
+    function _implementation() internal view virtual returns (address);
+
+    /**
+     * @dev Delegates the current call to the address returned by `_implementation()`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _fallback() internal virtual {
+        _beforeFallback();
+        _delegate(_implementation());
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if no other
+     * function in the contract matches the call data.
+     */
+    fallback () external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if call data
+     * is empty.
+     */
+    receive () external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Hook that is called before falling back to the implementation. Can happen as part of a manual `_fallback`
+     * call, or as part of the Solidity `fallback` or `receive` functions.
+     *
+     * If overriden should call `super._beforeFallback()`.
+     */
+    function _beforeFallback() internal virtual {
+    }
+}
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: value }(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data, string memory errorMessage) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    function _verifyCallResult(bool success, bytes memory returndata, string memory errorMessage) private pure returns(bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+/**
+ * @dev Interface of the ERC165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[EIP].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+
+/**
+ * @dev Implementation of the {IERC165} interface.
+ *
+ * Contracts may inherit from this and call {_registerInterface} to declare
+ * their support of an interface.
+ */
+abstract contract ERC165 is IERC165 {
+    /*
+     * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
+     */
+    bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
+
+    /**
+     * @dev Mapping of interface ids to whether or not it's supported.
+     */
+    mapping(bytes4 => bool) private _supportedInterfaces;
+
+    constructor () {
+        // Derived contracts need only register support for their own interfaces,
+        // we register support for ERC165 itself here
+        _registerInterface(_INTERFACE_ID_ERC165);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     *
+     * Time complexity O(1), guaranteed to always use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return _supportedInterfaces[interfaceId];
+    }
+
+    /**
+     * @dev Registers the contract as an implementer of the interface defined by
+     * `interfaceId`. Support of the actual ERC165 interface is automatic and
+     * registering its interface id is not required.
+     *
+     * See {IERC165-supportsInterface}.
+     *
+     * Requirements:
+     *
+     * - `interfaceId` cannot be the ERC165 invalid interface (`0xffffffff`).
+     */
+    function _registerInterface(bytes4 interfaceId) internal virtual {
+        require(interfaceId != 0xffffffff, "ERC165: invalid interface id");
+        _supportedInterfaces[interfaceId] = true;
+    }
+}
+
+/**
+ * _Available since v3.1._
+ */
+interface IERC1155Receiver is IERC165 {
+
+    /**
+        @dev Handles the receipt of a single ERC1155 token type. This function is
+        called at the end of a `safeTransferFrom` after the balance has been updated.
+        To accept the transfer, this must return
+        `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
+        (i.e. 0xf23a6e61, or its own function selector).
+        @param operator The address which initiated the transfer (i.e. msg.sender)
+        @param from The address which previously owned the token
+        @param id The ID of the token being transferred
+        @param value The amount of tokens being transferred
+        @param data Additional data with no specified format
+        @return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` if transfer is allowed
+    */
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+    )
+        external
+        returns(bytes4);
+
+    /**
+        @dev Handles the receipt of a multiple ERC1155 token types. This function
+        is called at the end of a `safeBatchTransferFrom` after the balances have
+        been updated. To accept the transfer(s), this must return
+        `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+        (i.e. 0xbc197c81, or its own function selector).
+        @param operator The address which initiated the batch transfer (i.e. msg.sender)
+        @param from The address which previously owned the token
+        @param ids An array containing ids of each token being transferred (order and length must match values array)
+        @param values An array containing amounts of each token being transferred (order and length must match ids array)
+        @param data Additional data with no specified format
+        @return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` if transfer is allowed
+    */
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    )
+        external
+        returns(bytes4);
+}
+
+
+/**
+ * @dev _Available since v3.1._
+ */
+abstract contract ERC1155Receiver is ERC165, IERC1155Receiver {
+    constructor() {
+        _registerInterface(
+            ERC1155Receiver(address(0)).onERC1155Received.selector ^
+            ERC1155Receiver(address(0)).onERC1155BatchReceived.selector
+        );
+    }
+}
+
+
+/**
+ * @dev _Available since v3.1._
+ */
+contract ERC1155Holder is ERC1155Receiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] memory, uint256[] memory, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155BatchReceived.selector;
+    }
+}
+
+
+
+interface IOperationsRegistry {
+    function allowedAssets(address asset) external view returns (bool);
+}
+
+interface IBPool {
+    function bind(
+        address token,
+        uint256 balance,
+        uint256 denorm
+    ) external;
+
+    function joinPool(uint256 poolAmountOut, uint256[] calldata maxAmountsIn) external;
+
+    function exitPool(uint256 poolAmountIn, uint256[] calldata minAmountsOut) external;
+
+    function swapExactAmountIn(
+        address tokenIn,
+        uint256 tokenAmountIn,
+        address tokenOut,
+        uint256 minAmountOut,
+        uint256 maxPrice
+    ) external returns (uint256 tokenAmountOut, uint256 spotPriceAfter);
+
+    function swapExactAmountOut(
+        address tokenIn,
+        uint256 maxAmountIn,
+        address tokenOut,
+        uint256 tokenAmountOut,
+        uint256 maxPrice
+    ) external returns (uint256 tokenAmountIn, uint256 spotPriceAfter);
+
+    function joinswapExternAmountIn(
+        address tokenIn,
+        uint256 tokenAmountIn,
+        uint256 minPoolAmountOut
+    ) external returns (uint256 poolAmountOut);
+
+    function joinswapPoolAmountOut(
+        address tokenIn,
+        uint256 poolAmountOut,
+        uint256 maxAmountIn
+    ) external returns (uint256 tokenAmountIn);
+
+    function exitswapPoolAmountIn(
+        address tokenOut,
+        uint256 poolAmountIn,
+        uint256 minAmountOut
+    ) external returns (uint256 tokenAmountOut);
+
+    function exitswapExternAmountOut(
+        address tokenOut,
+        uint256 tokenAmountOut,
+        uint256 maxPoolAmountIn
+    ) external returns (uint256 poolAmountIn);
+}
+
+contract BPoolExtend is Proxy, ERC1155Holder {
+    address public immutable implementation;
+    address public immutable exchangeProxy;
+    address public immutable operationsRegistry;
+
+    constructor(address _poolImpl, address _operationsRegistry, address _exchProxy, bytes memory _data) {
+        implementation = _poolImpl;
+        exchangeProxy = _exchProxy;
+        operationsRegistry = _operationsRegistry;
+
+        if(_data.length > 0) {
+            Address.functionDelegateCall(_poolImpl, _data);
+        }
+    }
+
+    function _implementation() internal view override returns (address) {
+        return implementation;
+    }
+
+    function _beforeFallback() internal view override {
+       _onlyExchangeProxy();
+       _onlyAllowedToken();
+    }
+
+    function _onlyExchangeProxy() internal view {
+        if (
+           msg.sig == IBPool.joinPool.selector ||
+           msg.sig == IBPool.exitPool.selector ||
+           msg.sig == IBPool.swapExactAmountIn.selector ||
+           msg.sig == IBPool.swapExactAmountOut.selector ||
+           msg.sig == IBPool.joinswapExternAmountIn.selector ||
+           msg.sig == IBPool.joinswapPoolAmountOut.selector ||
+           msg.sig == IBPool.exitswapPoolAmountIn.selector ||
+           msg.sig == IBPool.exitswapExternAmountOut.selector
+        ) {
+            require(msg.sender == exchangeProxy, "ERR_NOT_EXCHANGE_PROXY");
+       }
+    }
+
+    function _onlyAllowedToken() internal view {
+        if (msg.sig == IBPool.bind.selector) {
+            (address token, , ) = abi.decode(msg.data[4:], (address, address, uint256));
+            require(IOperationsRegistry(operationsRegistry).allowedAssets(token), "ERR_NOT_ALLOWED_TOKEN");
+        }
+    }
+}
+
+interface IBpool {
+    function initialize() external;
+
+    function setController(address manager) external;
+}
+
+interface IPermissionManager {
+    function assignItem(uint256 _itemId, address[] memory _accounts) external;
+}
+
+contract BFactory is BBronze, Authorizable {
+    event LOG_NEW_POOL(address indexed caller, address indexed pool);
+
+    event LOG_BLABS(address indexed caller, address indexed blabs);
+
+    event LOG_POOLIMPL(address indexed caller, address indexed poolImpl);
+
+    event LOG_EXCHPROXY(address indexed caller, address indexed exchProxy);
+
+    event LOG_OPERATIONREGISTRY(address indexed caller, address indexed operationsRegistry);
+
+    event LOG_PERMISSIONMANAGER(address indexed caller, address indexed permissionManager);
+
+    mapping(address => bool) private _isBPool;
+
+    function isBPool(address b) external view returns (bool) {
+        return _isBPool[b];
+    }
+
+    function newBPool() external onlyAuthorized returns (BPoolExtend) {
+        require(_operationsRegistry != address(0), "ERR_OP_REG_NOT_INITIALIZED");
+        require(_exchProxy != address(0), "ERR_EXCH_PROXY_NOT_INITIALIZED");
+        require(_permissionManager != address(0), "ERR_PERM_MAN_NOT_INITIALIZED");
+        BPoolExtend bpool = new BPoolExtend(
+            _poolImpl,
+            _operationsRegistry,
+            _exchProxy,
+            abi.encodeWithSignature("initialize()")
+        );
+        _isBPool[address(bpool)] = true;
+        emit LOG_NEW_POOL(msg.sender, address(bpool));
+        IBpool(address(bpool)).setController(msg.sender);
+        address[] memory accounts = new address[](1);
+        accounts[0] = address(bpool);
+        IPermissionManager(_permissionManager).assignItem(2, accounts);
+        return bpool;
+    }
+
+    address private _blabs;
+    address public _poolImpl;
+    address public _exchProxy;
+    address public _operationsRegistry;
+    address public _permissionManager;
+
+    constructor(address poolImpl) public {
+        _blabs = msg.sender;
+        _poolImpl = poolImpl;
+    }
+
+    function getBLabs() external view returns (address) {
+        return _blabs;
+    }
+
+    function setBLabs(address b) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_BLABS(msg.sender, b);
+        _blabs = b;
+    }
+
+    function setPoolImpl(address poolImpl) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_POOLIMPL(msg.sender, poolImpl);
+        _poolImpl = poolImpl;
+    }
+
+    function setExchProxy(address exchProxy) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_EXCHPROXY(msg.sender, exchProxy);
+        _exchProxy = exchProxy;
+    }
+
+    function setOperationsRegistry(address operationsRegistry) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_OPERATIONREGISTRY(msg.sender, operationsRegistry);
+        _operationsRegistry = operationsRegistry;
+    }
+
+    function setPermissionManager(address permissionManager) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_PERMISSIONMANAGER(msg.sender, permissionManager);
+        _permissionManager = permissionManager;
+    }
+
+    function setAuthorization(address _authorization) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        _setAuthorization(_authorization);
+    }
+
+    function collect(IERC20 pool) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        uint256 collected = pool.balanceOf(address(this));
+        bool xfer = pool.transfer(_blabs, collected);
+        require(xfer, "ERR_ERC20_FAILED");
+    }
+}

--- a/contracts/verify-bfactory/Address.sol
+++ b/contracts/verify-bfactory/Address.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: value }(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data, string memory errorMessage) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    function _verifyCallResult(bool success, bytes memory returndata, string memory errorMessage) private pure returns(bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}

--- a/contracts/verify-bfactory/Authorizable.sol
+++ b/contracts/verify-bfactory/Authorizable.sol
@@ -1,0 +1,43 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.7.0;
+
+import "./Context.sol";
+import "./IAuthorization.sol";
+
+/**
+ * @title Authorizable
+ * @author Protofire
+ * @dev Contract module which provides an authorization mechanism.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyAuthorized`, which can be applied to your functions to restrict their use.
+ */
+abstract contract Authorizable is Context {
+    IAuthorization public authorization;
+
+    /**
+     * @dev Emitted when `authorization` address is setted.
+     */
+    event AuthorizationSetted(address indexed newAuthorization);
+
+    /**
+     * @dev Throws if called by any account which is not authorized to execute the transaction.
+     */
+    modifier onlyAuthorized() {
+        require(
+            authorization.isAuthorized(_msgSender(), address(this), msg.sig, _msgData()),
+            "Authorizable: not authorized"
+        );
+        _;
+    }
+
+    /**
+     * @dev Sets authorization.
+     *
+     */
+    function _setAuthorization(address authorization_) internal {
+        require(authorization_ != address(0), "Authorizable: authorization is the zero address");
+        authorization = IAuthorization(authorization_);
+        emit AuthorizationSetted(authorization_);
+    }
+}

--- a/contracts/verify-bfactory/BColor.sol
+++ b/contracts/verify-bfactory/BColor.sol
@@ -1,0 +1,28 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+abstract contract BColor {
+    function getColor()
+        external virtual view
+        returns (bytes32);
+}
+
+contract BBronze is BColor {
+    function getColor()
+        external override view
+        returns (bytes32) {
+            return bytes32("BRONZE");
+        }
+}

--- a/contracts/verify-bfactory/BFactory.sol
+++ b/contracts/verify-bfactory/BFactory.sol
@@ -1,0 +1,127 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is disstributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+// Builds new BPools, logging their addresses and providing `isBPool(address) -> (bool)`
+
+import "./BColor.sol";
+import "./BPoolExtend.sol";
+import "./IERC20.sol";
+import "./Authorizable.sol";
+
+interface IBpool {
+    function initialize() external;
+
+    function setController(address manager) external;
+}
+
+interface IPermissionManager {
+    function assignItem(uint256 _itemId, address[] memory _accounts) external;
+}
+
+contract BFactory is BBronze, Authorizable {
+    event LOG_NEW_POOL(address indexed caller, address indexed pool);
+
+    event LOG_BLABS(address indexed caller, address indexed blabs);
+
+    event LOG_POOLIMPL(address indexed caller, address indexed poolImpl);
+
+    event LOG_EXCHPROXY(address indexed caller, address indexed exchProxy);
+
+    event LOG_OPERATIONREGISTRY(address indexed caller, address indexed operationsRegistry);
+
+    event LOG_PERMISSIONMANAGER(address indexed caller, address indexed permissionManager);
+
+    mapping(address => bool) private _isBPool;
+
+    function isBPool(address b) external view returns (bool) {
+        return _isBPool[b];
+    }
+
+    function newBPool() external onlyAuthorized returns (BPoolExtend) {
+        require(_operationsRegistry != address(0), "ERR_OP_REG_NOT_INITIALIZED");
+        require(_exchProxy != address(0), "ERR_EXCH_PROXY_NOT_INITIALIZED");
+        require(_permissionManager != address(0), "ERR_PERM_MAN_NOT_INITIALIZED");
+        BPoolExtend bpool = new BPoolExtend(
+            _poolImpl,
+            _operationsRegistry,
+            _exchProxy,
+            abi.encodeWithSignature("initialize()")
+        );
+        _isBPool[address(bpool)] = true;
+        emit LOG_NEW_POOL(msg.sender, address(bpool));
+        IBpool(address(bpool)).setController(msg.sender);
+        address[] memory accounts = new address[](1);
+        accounts[0] = address(bpool);
+        IPermissionManager(_permissionManager).assignItem(2, accounts);
+        return bpool;
+    }
+
+    address private _blabs;
+    address public _poolImpl;
+    address public _exchProxy;
+    address public _operationsRegistry;
+    address public _permissionManager;
+
+    constructor(address poolImpl) public {
+        _blabs = msg.sender;
+        _poolImpl = poolImpl;
+    }
+
+    function getBLabs() external view returns (address) {
+        return _blabs;
+    }
+
+    function setBLabs(address b) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_BLABS(msg.sender, b);
+        _blabs = b;
+    }
+
+    function setPoolImpl(address poolImpl) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_POOLIMPL(msg.sender, poolImpl);
+        _poolImpl = poolImpl;
+    }
+
+    function setExchProxy(address exchProxy) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_EXCHPROXY(msg.sender, exchProxy);
+        _exchProxy = exchProxy;
+    }
+
+    function setOperationsRegistry(address operationsRegistry) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_OPERATIONREGISTRY(msg.sender, operationsRegistry);
+        _operationsRegistry = operationsRegistry;
+    }
+
+    function setPermissionManager(address permissionManager) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        emit LOG_PERMISSIONMANAGER(msg.sender, permissionManager);
+        _permissionManager = permissionManager;
+    }
+
+    function setAuthorization(address _authorization) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        _setAuthorization(_authorization);
+    }
+
+    function collect(IERC20 pool) external {
+        require(msg.sender == _blabs, "ERR_NOT_BLABS");
+        uint256 collected = pool.balanceOf(address(this));
+        bool xfer = pool.transfer(_blabs, collected);
+        require(xfer, "ERR_ERC20_FAILED");
+    }
+}

--- a/contracts/verify-bfactory/BPoolExtend.sol
+++ b/contracts/verify-bfactory/BPoolExtend.sol
@@ -1,0 +1,121 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "./Proxy.sol";
+import "./Address.sol";
+import "./ERC1155Holder.sol";
+
+interface IOperationsRegistry {
+    function allowedAssets(address asset) external view returns (bool);
+}
+
+interface IBPool {
+    function bind(
+        address token,
+        uint256 balance,
+        uint256 denorm
+    ) external;
+
+    function joinPool(uint256 poolAmountOut, uint256[] calldata maxAmountsIn) external;
+
+    function exitPool(uint256 poolAmountIn, uint256[] calldata minAmountsOut) external;
+
+    function swapExactAmountIn(
+        address tokenIn,
+        uint256 tokenAmountIn,
+        address tokenOut,
+        uint256 minAmountOut,
+        uint256 maxPrice
+    ) external returns (uint256 tokenAmountOut, uint256 spotPriceAfter);
+
+    function swapExactAmountOut(
+        address tokenIn,
+        uint256 maxAmountIn,
+        address tokenOut,
+        uint256 tokenAmountOut,
+        uint256 maxPrice
+    ) external returns (uint256 tokenAmountIn, uint256 spotPriceAfter);
+
+    function joinswapExternAmountIn(
+        address tokenIn,
+        uint256 tokenAmountIn,
+        uint256 minPoolAmountOut
+    ) external returns (uint256 poolAmountOut);
+
+    function joinswapPoolAmountOut(
+        address tokenIn,
+        uint256 poolAmountOut,
+        uint256 maxAmountIn
+    ) external returns (uint256 tokenAmountIn);
+
+    function exitswapPoolAmountIn(
+        address tokenOut,
+        uint256 poolAmountIn,
+        uint256 minAmountOut
+    ) external returns (uint256 tokenAmountOut);
+
+    function exitswapExternAmountOut(
+        address tokenOut,
+        uint256 tokenAmountOut,
+        uint256 maxPoolAmountIn
+    ) external returns (uint256 poolAmountIn);
+}
+
+contract BPoolExtend is Proxy, ERC1155Holder {
+    address public immutable implementation;
+    address public immutable exchangeProxy;
+    address public immutable operationsRegistry;
+
+    constructor(address _poolImpl, address _operationsRegistry, address _exchProxy, bytes memory _data) {
+        implementation = _poolImpl;
+        exchangeProxy = _exchProxy;
+        operationsRegistry = _operationsRegistry;
+
+        if(_data.length > 0) {
+            Address.functionDelegateCall(_poolImpl, _data);
+        }
+    }
+
+    function _implementation() internal view override returns (address) {
+        return implementation;
+    }
+
+    function _beforeFallback() internal view override {
+       _onlyExchangeProxy();
+       _onlyAllowedToken();
+    }
+
+    function _onlyExchangeProxy() internal view {
+        if (
+           msg.sig == IBPool.joinPool.selector ||
+           msg.sig == IBPool.exitPool.selector ||
+           msg.sig == IBPool.swapExactAmountIn.selector ||
+           msg.sig == IBPool.swapExactAmountOut.selector ||
+           msg.sig == IBPool.joinswapExternAmountIn.selector ||
+           msg.sig == IBPool.joinswapPoolAmountOut.selector ||
+           msg.sig == IBPool.exitswapPoolAmountIn.selector ||
+           msg.sig == IBPool.exitswapExternAmountOut.selector
+        ) {
+            require(msg.sender == exchangeProxy, "ERR_NOT_EXCHANGE_PROXY");
+       }
+    }
+
+    function _onlyAllowedToken() internal view {
+        if (msg.sig == IBPool.bind.selector) {
+            (address token, , ) = abi.decode(msg.data[4:], (address, address, uint256));
+            require(IOperationsRegistry(operationsRegistry).allowedAssets(token), "ERR_NOT_ALLOWED_TOKEN");
+        }
+    }
+}

--- a/contracts/verify-bfactory/Context.sol
+++ b/contracts/verify-bfactory/Context.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}

--- a/contracts/verify-bfactory/ERC1155Holder.sol
+++ b/contracts/verify-bfactory/ERC1155Holder.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "./ERC1155Receiver.sol";
+
+/**
+ * @dev _Available since v3.1._
+ */
+contract ERC1155Holder is ERC1155Receiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] memory, uint256[] memory, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155BatchReceived.selector;
+    }
+}

--- a/contracts/verify-bfactory/ERC1155Receiver.sol
+++ b/contracts/verify-bfactory/ERC1155Receiver.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "./IERC1155Receiver.sol";
+import "./ERC165.sol";
+
+/**
+ * @dev _Available since v3.1._
+ */
+abstract contract ERC1155Receiver is ERC165, IERC1155Receiver {
+    constructor() {
+        _registerInterface(
+            ERC1155Receiver(address(0)).onERC1155Received.selector ^
+            ERC1155Receiver(address(0)).onERC1155BatchReceived.selector
+        );
+    }
+}

--- a/contracts/verify-bfactory/ERC165.sol
+++ b/contracts/verify-bfactory/ERC165.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "./IERC165.sol";
+
+/**
+ * @dev Implementation of the {IERC165} interface.
+ *
+ * Contracts may inherit from this and call {_registerInterface} to declare
+ * their support of an interface.
+ */
+abstract contract ERC165 is IERC165 {
+    /*
+     * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
+     */
+    bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
+
+    /**
+     * @dev Mapping of interface ids to whether or not it's supported.
+     */
+    mapping(bytes4 => bool) private _supportedInterfaces;
+
+    constructor () {
+        // Derived contracts need only register support for their own interfaces,
+        // we register support for ERC165 itself here
+        _registerInterface(_INTERFACE_ID_ERC165);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     *
+     * Time complexity O(1), guaranteed to always use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return _supportedInterfaces[interfaceId];
+    }
+
+    /**
+     * @dev Registers the contract as an implementer of the interface defined by
+     * `interfaceId`. Support of the actual ERC165 interface is automatic and
+     * registering its interface id is not required.
+     *
+     * See {IERC165-supportsInterface}.
+     *
+     * Requirements:
+     *
+     * - `interfaceId` cannot be the ERC165 invalid interface (`0xffffffff`).
+     */
+    function _registerInterface(bytes4 interfaceId) internal virtual {
+        require(interfaceId != 0xffffffff, "ERC165: invalid interface id");
+        _supportedInterfaces[interfaceId] = true;
+    }
+}

--- a/contracts/verify-bfactory/IAuthorization.sol
+++ b/contracts/verify-bfactory/IAuthorization.sol
@@ -1,0 +1,54 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.7.0;
+
+/**
+ * @title IAuthorization
+ * @author Protofire
+ * @dev Interface to be implemented by any Authorization logic contract.
+ *
+ */
+interface IAuthorization {
+    /**
+     * @dev Sets `_permissions` as the new Permissions module.
+     *
+     * @param _permissions The address of the new Pemissions module.
+     */
+    function setPermissions(address _permissions) external returns (bool);
+
+    /**
+     * @dev Sets `_eurPriceFeed` as the new EUR Price feed module.
+     *
+     * @param _eurPriceFeed The address of the new EUR Price feed module.
+     */
+    function setEurPriceFeed(address _eurPriceFeed) external returns (bool);
+
+    /**
+     * @dev Sets `_operationsRegistry` as the new OperationsRegistry module.
+     *
+     * @param _operationsRegistry The address of the new OperationsRegistry module.
+     */
+    function setOperationsRegistry(address _operationsRegistry) external returns (bool);
+
+    /**
+     * @dev Sets `_tradingLimit` as the new traiding limit.
+     *
+     * @param _tradingLimit The value of the new traiding limit.
+     */
+    function setTradingLimint(uint256 _tradingLimit) external returns (bool);
+
+    /**
+     * @dev Determins if a user is allowed to perform an operation.
+     *
+     * @param _user msg.sender from function using Authorizable `onlyAuthorized` modifier.
+     * @param _asset address of the contract using Authorizable `onlyAuthorized` modifier.
+     * @param _operation msg.sig from function using Authorizable `onlyAuthorized` modifier.
+     * @param _data msg.data from function using Authorizable `onlyAuthorized` modifier.
+     * @return a boolean signaling the authorization.
+     */
+    function isAuthorized(
+        address _user,
+        address _asset,
+        bytes4 _operation,
+        bytes calldata _data
+    ) external returns (bool);
+}

--- a/contracts/verify-bfactory/IERC1155Receiver.sol
+++ b/contracts/verify-bfactory/IERC1155Receiver.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "./IERC165.sol";
+
+/**
+ * _Available since v3.1._
+ */
+interface IERC1155Receiver is IERC165 {
+
+    /**
+        @dev Handles the receipt of a single ERC1155 token type. This function is
+        called at the end of a `safeTransferFrom` after the balance has been updated.
+        To accept the transfer, this must return
+        `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
+        (i.e. 0xf23a6e61, or its own function selector).
+        @param operator The address which initiated the transfer (i.e. msg.sender)
+        @param from The address which previously owned the token
+        @param id The ID of the token being transferred
+        @param value The amount of tokens being transferred
+        @param data Additional data with no specified format
+        @return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` if transfer is allowed
+    */
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+    )
+        external
+        returns(bytes4);
+
+    /**
+        @dev Handles the receipt of a multiple ERC1155 token types. This function
+        is called at the end of a `safeBatchTransferFrom` after the balances have
+        been updated. To accept the transfer(s), this must return
+        `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+        (i.e. 0xbc197c81, or its own function selector).
+        @param operator The address which initiated the batch transfer (i.e. msg.sender)
+        @param from The address which previously owned the token
+        @param ids An array containing ids of each token being transferred (order and length must match values array)
+        @param values An array containing amounts of each token being transferred (order and length must match ids array)
+        @param data Additional data with no specified format
+        @return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` if transfer is allowed
+    */
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    )
+        external
+        returns(bytes4);
+}

--- a/contracts/verify-bfactory/IERC165.sol
+++ b/contracts/verify-bfactory/IERC165.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev Interface of the ERC165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[EIP].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}

--- a/contracts/verify-bfactory/IERC20.sol
+++ b/contracts/verify-bfactory/IERC20.sol
@@ -1,0 +1,26 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+interface IERC20 {
+    function totalSupply() external view returns (uint);
+    function balanceOf(address whom) external view returns (uint);
+    function allowance(address src, address dst) external view returns (uint);
+
+    function approve(address dst, uint amt) external returns (bool);
+    function transfer(address dst, uint amt) external returns (bool);
+    function transferFrom(
+        address src, address dst, uint amt
+    ) external returns (bool);
+}

--- a/contracts/verify-bfactory/Proxy.sol
+++ b/contracts/verify-bfactory/Proxy.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM
+ * instruction `delegatecall`. We refer to the second contract as the _implementation_ behind the proxy, and it has to
+ * be specified by overriding the virtual {_implementation} function.
+ *
+ * Additionally, delegation to the implementation can be triggered manually through the {_fallback} function, or to a
+ * different contract through the {_delegate} function.
+ *
+ * The success and return data of the delegated call will be returned back to the caller of the proxy.
+ */
+abstract contract Proxy {
+    /**
+     * @dev Delegates the current call to `implementation`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _delegate(address implementation) internal virtual {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    /**
+     * @dev This is a virtual function that should be overriden so it returns the address to which the fallback function
+     * and {_fallback} should delegate.
+     */
+    function _implementation() internal view virtual returns (address);
+
+    /**
+     * @dev Delegates the current call to the address returned by `_implementation()`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _fallback() internal virtual {
+        _beforeFallback();
+        _delegate(_implementation());
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if no other
+     * function in the contract matches the call data.
+     */
+    fallback () external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if call data
+     * is empty.
+     */
+    receive () external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Hook that is called before falling back to the implementation. Can happen as part of a manual `_fallback`
+     * call, or as part of the Solidity `fallback` or `receive` functions.
+     *
+     * If overriden should call `super._beforeFallback()`.
+     */
+    function _beforeFallback() internal virtual {
+    }
+}

--- a/contracts/verify-bpool-impl/ALL_IN_ONE.sol
+++ b/contracts/verify-bpool-impl/ALL_IN_ONE.sol
@@ -1,0 +1,1547 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+
+
+abstract contract BColor {
+    function getColor()
+        external virtual view
+        returns (bytes32);
+}
+
+contract BBronze is BColor {
+    function getColor()
+        external override view
+        returns (bytes32) {
+            return bytes32("BRONZE");
+        }
+}
+
+
+contract BConst is BBronze {
+    uint public constant BONE              = 10**18;
+
+    uint public constant MIN_BOUND_TOKENS  = 2;
+    uint public constant MAX_BOUND_TOKENS  = 8;
+
+    uint public constant MIN_FEE           = BONE / 10**6;
+    uint public constant MAX_FEE           = BONE / 10;
+    uint public constant EXIT_FEE          = 0;
+
+    uint public constant MIN_WEIGHT        = BONE;
+    uint public constant MAX_WEIGHT        = BONE * 50;
+    uint public constant MAX_TOTAL_WEIGHT  = BONE * 50;
+    uint public constant MIN_BALANCE       = BONE / 10**12;
+
+    uint public constant INIT_POOL_SUPPLY  = BONE * 100;
+
+    uint public constant MIN_BPOW_BASE     = 1 wei;
+    uint public constant MAX_BPOW_BASE     = (2 * BONE) - 1 wei;
+    uint public constant BPOW_PRECISION    = BONE / 10**10;
+
+    uint public constant MAX_IN_RATIO      = BONE / 2;
+    uint public constant MAX_OUT_RATIO     = (BONE / 3) + 1 wei;
+}
+
+
+contract BNum is BConst {
+
+    function btoi(uint a)
+        internal pure
+        returns (uint)
+    {
+        return a / BONE;
+    }
+
+    function bfloor(uint a)
+        internal pure
+        returns (uint)
+    {
+        return btoi(a) * BONE;
+    }
+
+    function badd(uint a, uint b)
+        internal pure
+        returns (uint)
+    {
+        uint c = a + b;
+        require(c >= a, "ERR_ADD_OVERFLOW");
+        return c;
+    }
+
+    function bsub(uint a, uint b)
+        internal pure
+        returns (uint)
+    {
+        (uint c, bool flag) = bsubSign(a, b);
+        require(!flag, "ERR_SUB_UNDERFLOW");
+        return c;
+    }
+
+    function bsubSign(uint a, uint b)
+        internal pure
+        returns (uint, bool)
+    {
+        if (a >= b) {
+            return (a - b, false);
+        } else {
+            return (b - a, true);
+        }
+    }
+
+    function bmul(uint a, uint b)
+        internal pure
+        returns (uint)
+    {
+        uint c0 = a * b;
+        require(a == 0 || c0 / a == b, "ERR_MUL_OVERFLOW");
+        uint c1 = c0 + (BONE / 2);
+        require(c1 >= c0, "ERR_MUL_OVERFLOW");
+        uint c2 = c1 / BONE;
+        return c2;
+    }
+
+    function bdiv(uint a, uint b)
+        internal pure
+        returns (uint)
+    {
+        require(b != 0, "ERR_DIV_ZERO");
+        uint c0 = a * BONE;
+        require(a == 0 || c0 / a == BONE, "ERR_DIV_INTERNAL"); // bmul overflow
+        uint c1 = c0 + (b / 2);
+        require(c1 >= c0, "ERR_DIV_INTERNAL"); //  badd require
+        uint c2 = c1 / b;
+        return c2;
+    }
+
+    // DSMath.wpow
+    function bpowi(uint a, uint n)
+        internal pure
+        returns (uint)
+    {
+        uint z = n % 2 != 0 ? a : BONE;
+
+        for (n /= 2; n != 0; n /= 2) {
+            a = bmul(a, a);
+
+            if (n % 2 != 0) {
+                z = bmul(z, a);
+            }
+        }
+        return z;
+    }
+
+    // Compute b^(e.w) by splitting it into (b^e)*(b^0.w).
+    // Use `bpowi` for `b^e` and `bpowK` for k iterations
+    // of approximation of b^0.w
+    function bpow(uint base, uint exp)
+        internal pure
+        returns (uint)
+    {
+        require(base >= MIN_BPOW_BASE, "ERR_BPOW_BASE_TOO_LOW");
+        require(base <= MAX_BPOW_BASE, "ERR_BPOW_BASE_TOO_HIGH");
+
+        uint whole  = bfloor(exp);
+        uint remain = bsub(exp, whole);
+
+        uint wholePow = bpowi(base, btoi(whole));
+
+        if (remain == 0) {
+            return wholePow;
+        }
+
+        uint partialResult = bpowApprox(base, remain, BPOW_PRECISION);
+        return bmul(wholePow, partialResult);
+    }
+
+    function bpowApprox(uint base, uint exp, uint precision)
+        internal pure
+        returns (uint)
+    {
+        // term 0:
+        uint a     = exp;
+        (uint x, bool xneg)  = bsubSign(base, BONE);
+        uint term = BONE;
+        uint sum   = term;
+        bool negative = false;
+
+
+        // term(k) = numer / denom
+        //         = (product(a - i - 1, i=1-->k) * x^k) / (k!)
+        // each iteration, multiply previous term by (a-(k-1)) * x / k
+        // continue until term is less than precision
+        for (uint i = 1; term >= precision; i++) {
+            uint bigK = i * BONE;
+            (uint c, bool cneg) = bsubSign(a, bsub(bigK, BONE));
+            term = bmul(term, bmul(c, x));
+            term = bdiv(term, bigK);
+            if (term == 0) break;
+
+            if (xneg) negative = !negative;
+            if (cneg) negative = !negative;
+            if (negative) {
+                sum = bsub(sum, term);
+            } else {
+                sum = badd(sum, term);
+            }
+        }
+
+        return sum;
+    }
+
+}
+
+
+contract BMath is BBronze, BConst, BNum {
+    /**********************************************************************************************
+    // calcSpotPrice                                                                             //
+    // sP = spotPrice                                                                            //
+    // bI = tokenBalanceIn                ( bI / wI )         1                                  //
+    // bO = tokenBalanceOut         sP =  -----------  *  ----------                             //
+    // wI = tokenWeightIn                 ( bO / wO )     ( 1 - sF )                             //
+    // wO = tokenWeightOut                                                                       //
+    // sF = swapFee                                                                              //
+    **********************************************************************************************/
+    function calcSpotPrice(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint swapFee
+    )
+        public pure
+        returns (uint spotPrice)
+    {
+        uint numer = bdiv(tokenBalanceIn, tokenWeightIn);
+        uint denom = bdiv(tokenBalanceOut, tokenWeightOut);
+        uint ratio = bdiv(numer, denom);
+        uint scale = bdiv(BONE, bsub(BONE, swapFee));
+        return  (spotPrice = bmul(ratio, scale));
+    }
+
+    /**********************************************************************************************
+    // calcOutGivenIn                                                                            //
+    // aO = tokenAmountOut                                                                       //
+    // bO = tokenBalanceOut                                                                      //
+    // bI = tokenBalanceIn              /      /            bI             \    (wI / wO) \      //
+    // aI = tokenAmountIn    aO = bO * |  1 - | --------------------------  | ^            |     //
+    // wI = tokenWeightIn               \      \ ( bI + ( aI * ( 1 - sF )) /              /      //
+    // wO = tokenWeightOut                                                                       //
+    // sF = swapFee                                                                              //
+    **********************************************************************************************/
+    function calcOutGivenIn(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint tokenAmountIn,
+        uint swapFee
+    )
+        public pure
+        returns (uint tokenAmountOut)
+    {
+        uint weightRatio = bdiv(tokenWeightIn, tokenWeightOut);
+        uint adjustedIn = bsub(BONE, swapFee);
+        adjustedIn = bmul(tokenAmountIn, adjustedIn);
+        uint y = bdiv(tokenBalanceIn, badd(tokenBalanceIn, adjustedIn));
+        uint foo = bpow(y, weightRatio);
+        uint bar = bsub(BONE, foo);
+        tokenAmountOut = bmul(tokenBalanceOut, bar);
+        return tokenAmountOut;
+    }
+
+    /**********************************************************************************************
+    // calcInGivenOut                                                                            //
+    // aI = tokenAmountIn                                                                        //
+    // bO = tokenBalanceOut               /  /     bO      \    (wO / wI)      \                 //
+    // bI = tokenBalanceIn          bI * |  | ------------  | ^            - 1  |                //
+    // aO = tokenAmountOut    aI =        \  \ ( bO - aO ) /                   /                 //
+    // wI = tokenWeightIn           --------------------------------------------                 //
+    // wO = tokenWeightOut                          ( 1 - sF )                                   //
+    // sF = swapFee                                                                              //
+    **********************************************************************************************/
+    function calcInGivenOut(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint tokenAmountOut,
+        uint swapFee
+    )
+        public pure
+        returns (uint tokenAmountIn)
+    {
+        uint weightRatio = bdiv(tokenWeightOut, tokenWeightIn);
+        uint diff = bsub(tokenBalanceOut, tokenAmountOut);
+        uint y = bdiv(tokenBalanceOut, diff);
+        uint foo = bpow(y, weightRatio);
+        foo = bsub(foo, BONE);
+        tokenAmountIn = bsub(BONE, swapFee);
+        tokenAmountIn = bdiv(bmul(tokenBalanceIn, foo), tokenAmountIn);
+        return tokenAmountIn;
+    }
+
+    /**********************************************************************************************
+    // calcPoolOutGivenSingleIn                                                                  //
+    // pAo = poolAmountOut         /                                              \              //
+    // tAi = tokenAmountIn        ///      /     //    wI \      \\       \     wI \             //
+    // wI = tokenWeightIn        //| tAi *| 1 - || 1 - --  | * sF || + tBi \    --  \            //
+    // tW = totalWeight     pAo=||  \      \     \\    tW /      //         | ^ tW   | * pS - pS //
+    // tBi = tokenBalanceIn      \\  ------------------------------------- /        /            //
+    // pS = poolSupply            \\                    tBi               /        /             //
+    // sF = swapFee                \                                              /              //
+    **********************************************************************************************/
+    function calcPoolOutGivenSingleIn(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint poolSupply,
+        uint totalWeight,
+        uint tokenAmountIn,
+        uint swapFee
+    )
+        public pure
+        returns (uint poolAmountOut)
+    {
+        // Charge the trading fee for the proportion of tokenAi
+        // which is implicitly traded to the other pool tokens.
+        // That proportion is (1- weightTokenIn)
+        // tokenAiAfterFee = tAi * (1 - (1-weightTi) * poolFee);
+        uint normalizedWeight = bdiv(tokenWeightIn, totalWeight);
+        uint zaz = bmul(bsub(BONE, normalizedWeight), swapFee);
+        uint tokenAmountInAfterFee = bmul(tokenAmountIn, bsub(BONE, zaz));
+
+        uint newTokenBalanceIn = badd(tokenBalanceIn, tokenAmountInAfterFee);
+        uint tokenInRatio = bdiv(newTokenBalanceIn, tokenBalanceIn);
+
+        // uint newPoolSupply = (ratioTi ^ weightTi) * poolSupply;
+        uint poolRatio = bpow(tokenInRatio, normalizedWeight);
+        uint newPoolSupply = bmul(poolRatio, poolSupply);
+        poolAmountOut = bsub(newPoolSupply, poolSupply);
+        return poolAmountOut;
+    }
+
+    /**********************************************************************************************
+    // calcSingleInGivenPoolOut                                                                  //
+    // tAi = tokenAmountIn              //(pS + pAo)\     /    1    \\                           //
+    // pS = poolSupply                 || ---------  | ^ | --------- || * bI - bI                //
+    // pAo = poolAmountOut              \\    pS    /     \(wI / tW)//                           //
+    // bI = balanceIn          tAi =  --------------------------------------------               //
+    // wI = weightIn                              /      wI  \                                   //
+    // tW = totalWeight                          |  1 - ----  |  * sF                            //
+    // sF = swapFee                               \      tW  /                                   //
+    **********************************************************************************************/
+    function calcSingleInGivenPoolOut(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint poolSupply,
+        uint totalWeight,
+        uint poolAmountOut,
+        uint swapFee
+    )
+        public pure
+        returns (uint tokenAmountIn)
+    {
+        uint normalizedWeight = bdiv(tokenWeightIn, totalWeight);
+        uint newPoolSupply = badd(poolSupply, poolAmountOut);
+        uint poolRatio = bdiv(newPoolSupply, poolSupply);
+
+        //uint newBalTi = poolRatio^(1/weightTi) * balTi;
+        uint boo = bdiv(BONE, normalizedWeight);
+        uint tokenInRatio = bpow(poolRatio, boo);
+        uint newTokenBalanceIn = bmul(tokenInRatio, tokenBalanceIn);
+        uint tokenAmountInAfterFee = bsub(newTokenBalanceIn, tokenBalanceIn);
+        // Do reverse order of fees charged in joinswap_ExternAmountIn, this way
+        //     ``` pAo == joinswap_ExternAmountIn(Ti, joinswap_PoolAmountOut(pAo, Ti)) ```
+        //uint tAi = tAiAfterFee / (1 - (1-weightTi) * swapFee) ;
+        uint zar = bmul(bsub(BONE, normalizedWeight), swapFee);
+        tokenAmountIn = bdiv(tokenAmountInAfterFee, bsub(BONE, zar));
+        return tokenAmountIn;
+    }
+
+    /**********************************************************************************************
+    // calcSingleOutGivenPoolIn                                                                  //
+    // tAo = tokenAmountOut            /      /                                             \\   //
+    // bO = tokenBalanceOut           /      // pS - (pAi * (1 - eF)) \     /    1    \      \\  //
+    // pAi = poolAmountIn            | bO - || ----------------------- | ^ | --------- | * b0 || //
+    // ps = poolSupply                \      \\          pS           /     \(wO / tW)/      //  //
+    // wI = tokenWeightIn      tAo =   \      \                                             //   //
+    // tW = totalWeight                    /     /      wO \       \                             //
+    // sF = swapFee                    *  | 1 - |  1 - ---- | * sF  |                            //
+    // eF = exitFee                        \     \      tW /       /                             //
+    **********************************************************************************************/
+    function calcSingleOutGivenPoolIn(
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint poolSupply,
+        uint totalWeight,
+        uint poolAmountIn,
+        uint swapFee
+    )
+        public pure
+        returns (uint tokenAmountOut)
+    {
+        uint normalizedWeight = bdiv(tokenWeightOut, totalWeight);
+        // charge exit fee on the pool token side
+        // pAiAfterExitFee = pAi*(1-exitFee)
+        uint poolAmountInAfterExitFee = bmul(poolAmountIn, bsub(BONE, EXIT_FEE));
+        uint newPoolSupply = bsub(poolSupply, poolAmountInAfterExitFee);
+        uint poolRatio = bdiv(newPoolSupply, poolSupply);
+
+        // newBalTo = poolRatio^(1/weightTo) * balTo;
+        uint tokenOutRatio = bpow(poolRatio, bdiv(BONE, normalizedWeight));
+        uint newTokenBalanceOut = bmul(tokenOutRatio, tokenBalanceOut);
+
+        uint tokenAmountOutBeforeSwapFee = bsub(tokenBalanceOut, newTokenBalanceOut);
+
+        // charge swap fee on the output token side
+        //uint tAo = tAoBeforeSwapFee * (1 - (1-weightTo) * swapFee)
+        uint zaz = bmul(bsub(BONE, normalizedWeight), swapFee);
+        tokenAmountOut = bmul(tokenAmountOutBeforeSwapFee, bsub(BONE, zaz));
+        return tokenAmountOut;
+    }
+
+    /**********************************************************************************************
+    // calcPoolInGivenSingleOut                                                                  //
+    // pAi = poolAmountIn               // /               tAo             \\     / wO \     \   //
+    // bO = tokenBalanceOut            // | bO - -------------------------- |\   | ---- |     \  //
+    // tAo = tokenAmountOut      pS - ||   \     1 - ((1 - (tO / tW)) * sF)/  | ^ \ tW /  * pS | //
+    // ps = poolSupply                 \\ -----------------------------------/                /  //
+    // wO = tokenWeightOut  pAi =       \\               bO                 /                /   //
+    // tW = totalWeight           -------------------------------------------------------------  //
+    // sF = swapFee                                        ( 1 - eF )                            //
+    // eF = exitFee                                                                              //
+    **********************************************************************************************/
+    function calcPoolInGivenSingleOut(
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint poolSupply,
+        uint totalWeight,
+        uint tokenAmountOut,
+        uint swapFee
+    )
+        public pure
+        returns (uint poolAmountIn)
+    {
+
+        // charge swap fee on the output token side
+        uint normalizedWeight = bdiv(tokenWeightOut, totalWeight);
+        //uint tAoBeforeSwapFee = tAo / (1 - (1-weightTo) * swapFee) ;
+        uint zoo = bsub(BONE, normalizedWeight);
+        uint zar = bmul(zoo, swapFee);
+        uint tokenAmountOutBeforeSwapFee = bdiv(tokenAmountOut, bsub(BONE, zar));
+
+        uint newTokenBalanceOut = bsub(tokenBalanceOut, tokenAmountOutBeforeSwapFee);
+        uint tokenOutRatio = bdiv(newTokenBalanceOut, tokenBalanceOut);
+
+        //uint newPoolSupply = (ratioTo ^ weightTo) * poolSupply;
+        uint poolRatio = bpow(tokenOutRatio, normalizedWeight);
+        uint newPoolSupply = bmul(poolRatio, poolSupply);
+        uint poolAmountInAfterExitFee = bsub(poolSupply, newPoolSupply);
+
+        // charge exit fee on the pool token side
+        // pAi = pAiAfterExitFee/(1-exitFee)
+        poolAmountIn = bdiv(poolAmountInAfterExitFee, bsub(BONE, EXIT_FEE));
+        return poolAmountIn;
+    }
+
+
+}
+
+abstract contract BTokenBase is BNum {
+
+    mapping(address => uint)                   internal _balance;
+    mapping(address => mapping(address=>uint)) internal _allowance;
+    uint internal _totalSupply;
+
+    event Approval(address indexed src, address indexed dst, uint amt);
+    event Transfer(address indexed src, address indexed dst, uint amt);
+
+    function _mint(uint amt) internal {
+        _balance[address(this)] = badd(_balance[address(this)], amt);
+        _totalSupply = badd(_totalSupply, amt);
+        emit Transfer(address(0), address(this), amt);
+    }
+
+    function _burn(uint amt) internal {
+        require(_balance[address(this)] >= amt, "ERR_INSUFFICIENT_BAL");
+        _balance[address(this)] = bsub(_balance[address(this)], amt);
+        _totalSupply = bsub(_totalSupply, amt);
+        emit Transfer(address(this), address(0), amt);
+    }
+
+    function _move(address src, address dst, uint amt) internal {
+        require(_balance[src] >= amt, "ERR_INSUFFICIENT_BAL");
+        _balance[src] = bsub(_balance[src], amt);
+        _balance[dst] = badd(_balance[dst], amt);
+        emit Transfer(src, dst, amt);
+    }
+
+    function _push(address to, uint amt) internal {
+        _move(address(this), to, amt);
+    }
+
+    function _pull(address from, uint amt) internal {
+        _move(from, address(this), amt);
+    }
+}
+
+interface IERC20 {
+    function totalSupply() external view returns (uint);
+    function balanceOf(address whom) external view returns (uint);
+    function allowance(address src, address dst) external view returns (uint);
+
+    function approve(address dst, uint amt) external returns (bool);
+    function transfer(address dst, uint amt) external returns (bool);
+    function transferFrom(
+        address src, address dst, uint amt
+    ) external returns (bool);
+}
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: value }(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data, string memory errorMessage) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    function _verifyCallResult(bool success, bytes memory returndata, string memory errorMessage) private pure returns(bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ *
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {UpgradeableProxy-constructor}.
+ *
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ */
+abstract contract Initializable {
+
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private _initializing;
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier initializer() {
+        require(_initializing || _isConstructor() || !_initialized, "Initializable: contract is already initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function _isConstructor() private view returns (bool) {
+        return !Address.isContract(address(this));
+    }
+}
+
+
+
+abstract contract BToken is Initializable, BTokenBase, IERC20 {
+    string  private _name;
+    string  private _symbol;
+    uint8   private _decimals;
+
+    function __BToken_init_unchained() internal initializer {
+        _name     = "Swarm Markets Pool Token";
+        _symbol   = "SPT";
+        _decimals = 18;
+    }
+
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() public view returns(uint8) {
+        return _decimals;
+    }
+
+    function allowance(address src, address dst) external override view returns (uint) {
+        return _allowance[src][dst];
+    }
+
+    function balanceOf(address whom) external override view returns (uint) {
+        return _balance[whom];
+    }
+
+    function totalSupply() public override view returns (uint) {
+        return _totalSupply;
+    }
+
+    function approve(address dst, uint amt) external override returns (bool) {
+        _allowance[msg.sender][dst] = amt;
+        emit Approval(msg.sender, dst, amt);
+        return true;
+    }
+
+    function increaseApproval(address dst, uint amt) external returns (bool) {
+        _allowance[msg.sender][dst] = badd(_allowance[msg.sender][dst], amt);
+        emit Approval(msg.sender, dst, _allowance[msg.sender][dst]);
+        return true;
+    }
+
+    function decreaseApproval(address dst, uint amt) external returns (bool) {
+        uint oldValue = _allowance[msg.sender][dst];
+        if (amt > oldValue) {
+            _allowance[msg.sender][dst] = 0;
+        } else {
+            _allowance[msg.sender][dst] = bsub(oldValue, amt);
+        }
+        emit Approval(msg.sender, dst, _allowance[msg.sender][dst]);
+        return true;
+    }
+
+    function transfer(address dst, uint amt) external override returns (bool) {
+        _move(msg.sender, dst, amt);
+        return true;
+    }
+
+    function transferFrom(address src, address dst, uint amt) external override returns (bool) {
+        require(msg.sender == src || amt <= _allowance[src][msg.sender], "ERR_BTOKEN_BAD_CALLER");
+        _move(src, dst, amt);
+        if (msg.sender != src && _allowance[src][msg.sender] != uint256(-1)) {
+            _allowance[src][msg.sender] = bsub(_allowance[src][msg.sender], amt);
+            emit Approval(msg.sender, dst, _allowance[src][msg.sender]);
+        }
+        return true;
+    }
+}
+
+
+
+contract BPool is BBronze, BToken, BMath {
+
+    struct Record {
+        bool bound;   // is token bound to pool
+        uint index;   // private
+        uint denorm;  // denormalized weight
+        uint balance;
+    }
+
+    event LOG_SWAP(
+        address indexed caller,
+        address indexed tokenIn,
+        address indexed tokenOut,
+        uint256         tokenAmountIn,
+        uint256         tokenAmountOut
+    );
+
+    event LOG_JOIN(
+        address indexed caller,
+        address indexed tokenIn,
+        uint256         tokenAmountIn
+    );
+
+    event LOG_EXIT(
+        address indexed caller,
+        address indexed tokenOut,
+        uint256         tokenAmountOut
+    );
+
+    event LOG_CALL(
+        bytes4  indexed sig,
+        address indexed caller,
+        bytes           data
+    ) anonymous;
+
+    modifier _logs_() {
+        emit LOG_CALL(msg.sig, msg.sender, msg.data);
+        _;
+    }
+
+    modifier _lock_() {
+        require(!_mutex, "ERR_REENTRY");
+        _mutex = true;
+        _;
+        _mutex = false;
+    }
+
+    modifier _viewlock_() {
+        require(!_mutex, "ERR_REENTRY");
+        _;
+    }
+
+    bool private _mutex;
+
+    address private _factory;    // BFactory address to push token exitFee to
+    address private _controller; // has CONTROL role
+    bool private _publicSwap; // true if PUBLIC can call SWAP functions
+
+    // `setSwapFee` and `finalize` require CONTROL
+    // `finalize` sets `PUBLIC can SWAP`, `PUBLIC can JOIN`
+    uint private _swapFee;
+    bool private _finalized;
+
+    address[] private _tokens;
+    mapping(address=>Record) private  _records;
+    uint private _totalWeight;
+
+    function initialize() public initializer {
+        _controller = msg.sender;
+        _factory = msg.sender;
+        _swapFee = MIN_FEE;
+        _publicSwap = false;
+        _finalized = false;
+        __BToken_init_unchained();
+    }
+
+    function isPublicSwap()
+        external view
+        returns (bool)
+    {
+        return _publicSwap;
+    }
+
+    function isFinalized()
+        external view
+        returns (bool)
+    {
+        return _finalized;
+    }
+
+    function isBound(address t)
+        external view
+        returns (bool)
+    {
+        return _records[t].bound;
+    }
+
+    function getNumTokens()
+        external view
+        returns (uint)
+    {
+        return _tokens.length;
+    }
+
+    function getCurrentTokens()
+        external view _viewlock_
+        returns (address[] memory tokens)
+    {
+        return _tokens;
+    }
+
+    function getFinalTokens()
+        external view
+        _viewlock_
+        returns (address[] memory tokens)
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        return _tokens;
+    }
+
+    function getDenormalizedWeight(address token)
+        external view
+        _viewlock_
+        returns (uint)
+    {
+
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        return _records[token].denorm;
+    }
+
+    function getTotalDenormalizedWeight()
+        external view
+        _viewlock_
+        returns (uint)
+    {
+        return _totalWeight;
+    }
+
+    function getNormalizedWeight(address token)
+        external view
+        _viewlock_
+        returns (uint)
+    {
+
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        uint denorm = _records[token].denorm;
+        return bdiv(denorm, _totalWeight);
+    }
+
+    function getBalance(address token)
+        external view
+        _viewlock_
+        returns (uint)
+    {
+
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        return _records[token].balance;
+    }
+
+    function getSwapFee()
+        external view
+        _viewlock_
+        returns (uint)
+    {
+        return _swapFee;
+    }
+
+    function getController()
+        external view
+        _viewlock_
+        returns (address)
+    {
+        return _controller;
+    }
+
+    function setSwapFee(uint swapFee)
+        external
+        _logs_
+        _lock_
+    {
+        require(!_finalized, "ERR_IS_FINALIZED");
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(swapFee >= MIN_FEE, "ERR_MIN_FEE");
+        require(swapFee <= MAX_FEE, "ERR_MAX_FEE");
+        _swapFee = swapFee;
+    }
+
+    function setController(address manager)
+        external
+        _logs_
+        _lock_
+    {
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        _controller = manager;
+    }
+
+    function setPublicSwap(bool public_)
+        external
+        _logs_
+        _lock_
+    {
+        require(!_finalized, "ERR_IS_FINALIZED");
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        _publicSwap = public_;
+    }
+
+    function finalize()
+        external
+        _logs_
+        _lock_
+    {
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(!_finalized, "ERR_IS_FINALIZED");
+        require(_tokens.length >= MIN_BOUND_TOKENS, "ERR_MIN_TOKENS");
+
+        _finalized = true;
+        _publicSwap = true;
+
+        _mintPoolShare(INIT_POOL_SUPPLY);
+        _pushPoolShare(msg.sender, INIT_POOL_SUPPLY);
+    }
+
+
+    function bind(address token, uint balance, uint denorm)
+        external
+        _logs_
+        // _lock_  Bind does not lock because it jumps to `rebind`, which does
+    {
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(!_records[token].bound, "ERR_IS_BOUND");
+        require(!_finalized, "ERR_IS_FINALIZED");
+
+        require(_tokens.length < MAX_BOUND_TOKENS, "ERR_MAX_TOKENS");
+
+        _records[token] = Record({
+            bound: true,
+            index: _tokens.length,
+            denorm: 0,    // balance and denorm will be validated
+            balance: 0   // and set by `rebind`
+        });
+        _tokens.push(token);
+        rebind(token, balance, denorm);
+    }
+
+    function rebind(address token, uint balance, uint denorm)
+        public
+        _logs_
+        _lock_
+    {
+
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        require(!_finalized, "ERR_IS_FINALIZED");
+
+        require(denorm >= MIN_WEIGHT, "ERR_MIN_WEIGHT");
+        require(denorm <= MAX_WEIGHT, "ERR_MAX_WEIGHT");
+        require(balance >= MIN_BALANCE, "ERR_MIN_BALANCE");
+
+        // Adjust the denorm and totalWeight
+        uint oldWeight = _records[token].denorm;
+        if (denorm > oldWeight) {
+            _totalWeight = badd(_totalWeight, bsub(denorm, oldWeight));
+            require(_totalWeight <= MAX_TOTAL_WEIGHT, "ERR_MAX_TOTAL_WEIGHT");
+        } else if (denorm < oldWeight) {
+            _totalWeight = bsub(_totalWeight, bsub(oldWeight, denorm));
+        }
+        _records[token].denorm = denorm;
+
+        // Adjust the balance record and actual token balance
+        uint oldBalance = _records[token].balance;
+        _records[token].balance = balance;
+        if (balance > oldBalance) {
+            _pullUnderlying(token, msg.sender, bsub(balance, oldBalance));
+        } else if (balance < oldBalance) {
+            // In this case liquidity is being withdrawn, so charge EXIT_FEE
+            uint tokenBalanceWithdrawn = bsub(oldBalance, balance);
+            uint tokenExitFee = bmul(tokenBalanceWithdrawn, EXIT_FEE);
+            _pushUnderlying(token, msg.sender, bsub(tokenBalanceWithdrawn, tokenExitFee));
+            _pushUnderlying(token, _factory, tokenExitFee);
+        }
+    }
+
+    function unbind(address token)
+        external
+        _logs_
+        _lock_
+    {
+
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        require(!_finalized, "ERR_IS_FINALIZED");
+
+        uint tokenBalance = _records[token].balance;
+        uint tokenExitFee = bmul(tokenBalance, EXIT_FEE);
+
+        _totalWeight = bsub(_totalWeight, _records[token].denorm);
+
+        // Swap the token-to-unbind with the last token,
+        // then delete the last token
+        uint index = _records[token].index;
+        uint last = _tokens.length - 1;
+        _tokens[index] = _tokens[last];
+        _records[_tokens[index]].index = index;
+        _tokens.pop();
+        _records[token] = Record({
+            bound: false,
+            index: 0,
+            denorm: 0,
+            balance: 0
+        });
+
+        _pushUnderlying(token, msg.sender, bsub(tokenBalance, tokenExitFee));
+        _pushUnderlying(token, _factory, tokenExitFee);
+    }
+
+    // Absorb any tokens that have been sent to this contract into the pool
+    function gulp(address token)
+        external
+        _logs_
+        _lock_
+    {
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        _records[token].balance = IERC20(token).balanceOf(address(this));
+    }
+
+    function getSpotPrice(address tokenIn, address tokenOut)
+        external view
+        _viewlock_
+        returns (uint spotPrice)
+    {
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        Record storage inRecord = _records[tokenIn];
+        Record storage outRecord = _records[tokenOut];
+        return calcSpotPrice(inRecord.balance, inRecord.denorm, outRecord.balance, outRecord.denorm, _swapFee);
+    }
+
+    function getSpotPriceSansFee(address tokenIn, address tokenOut)
+        external view
+        _viewlock_
+        returns (uint spotPrice)
+    {
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        Record storage inRecord = _records[tokenIn];
+        Record storage outRecord = _records[tokenOut];
+        return calcSpotPrice(inRecord.balance, inRecord.denorm, outRecord.balance, outRecord.denorm, 0);
+    }
+
+    function joinPool(uint poolAmountOut, uint[] calldata maxAmountsIn)
+        external
+        _logs_
+        _lock_
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+
+        uint poolTotal = totalSupply();
+        uint ratio = bdiv(poolAmountOut, poolTotal);
+        require(ratio != 0, "ERR_MATH_APPROX");
+
+        for (uint i = 0; i < _tokens.length; i++) {
+            address t = _tokens[i];
+            uint bal = _records[t].balance;
+            uint tokenAmountIn = bmul(ratio, bal);
+            require(tokenAmountIn != 0, "ERR_MATH_APPROX");
+            require(tokenAmountIn <= maxAmountsIn[i], "ERR_LIMIT_IN");
+            _records[t].balance = badd(_records[t].balance, tokenAmountIn);
+            emit LOG_JOIN(msg.sender, t, tokenAmountIn);
+            _pullUnderlying(t, msg.sender, tokenAmountIn);
+        }
+        _mintPoolShare(poolAmountOut);
+        _pushPoolShare(msg.sender, poolAmountOut);
+    }
+
+    function exitPool(uint poolAmountIn, uint[] calldata minAmountsOut)
+        external
+        _logs_
+        _lock_
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+
+        uint poolTotal = totalSupply();
+        uint exitFee = bmul(poolAmountIn, EXIT_FEE);
+        uint pAiAfterExitFee = bsub(poolAmountIn, exitFee);
+        uint ratio = bdiv(pAiAfterExitFee, poolTotal);
+        require(ratio != 0, "ERR_MATH_APPROX");
+
+        _pullPoolShare(msg.sender, poolAmountIn);
+        _pushPoolShare(_factory, exitFee);
+        _burnPoolShare(pAiAfterExitFee);
+
+        for (uint i = 0; i < _tokens.length; i++) {
+            address t = _tokens[i];
+            uint bal = _records[t].balance;
+            uint tokenAmountOut = bmul(ratio, bal);
+            require(tokenAmountOut != 0, "ERR_MATH_APPROX");
+            require(tokenAmountOut >= minAmountsOut[i], "ERR_LIMIT_OUT");
+            _records[t].balance = bsub(_records[t].balance, tokenAmountOut);
+            emit LOG_EXIT(msg.sender, t, tokenAmountOut);
+            _pushUnderlying(t, msg.sender, tokenAmountOut);
+        }
+
+    }
+
+
+    function swapExactAmountIn(
+        address tokenIn,
+        uint tokenAmountIn,
+        address tokenOut,
+        uint minAmountOut,
+        uint maxPrice
+    )
+        external
+        _logs_
+        _lock_
+        returns (uint tokenAmountOut, uint spotPriceAfter)
+    {
+
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        require(_publicSwap, "ERR_SWAP_NOT_PUBLIC");
+
+        Record storage inRecord = _records[address(tokenIn)];
+        Record storage outRecord = _records[address(tokenOut)];
+
+        require(tokenAmountIn <= bmul(inRecord.balance, MAX_IN_RATIO), "ERR_MAX_IN_RATIO");
+
+        uint spotPriceBefore = calcSpotPrice(
+                                    inRecord.balance,
+                                    inRecord.denorm,
+                                    outRecord.balance,
+                                    outRecord.denorm,
+                                    _swapFee
+                                );
+        require(spotPriceBefore <= maxPrice, "ERR_BAD_LIMIT_PRICE");
+
+        tokenAmountOut = calcOutGivenIn(
+                            inRecord.balance,
+                            inRecord.denorm,
+                            outRecord.balance,
+                            outRecord.denorm,
+                            tokenAmountIn,
+                            _swapFee
+                        );
+        require(tokenAmountOut >= minAmountOut, "ERR_LIMIT_OUT");
+
+        inRecord.balance = badd(inRecord.balance, tokenAmountIn);
+        outRecord.balance = bsub(outRecord.balance, tokenAmountOut);
+
+        spotPriceAfter = calcSpotPrice(
+                                inRecord.balance,
+                                inRecord.denorm,
+                                outRecord.balance,
+                                outRecord.denorm,
+                                _swapFee
+                            );
+        require(spotPriceAfter >= spotPriceBefore, "ERR_MATH_APPROX");
+        require(spotPriceAfter <= maxPrice, "ERR_LIMIT_PRICE");
+        require(spotPriceBefore <= bdiv(tokenAmountIn, tokenAmountOut), "ERR_MATH_APPROX");
+
+        emit LOG_SWAP(msg.sender, tokenIn, tokenOut, tokenAmountIn, tokenAmountOut);
+
+        _pullUnderlying(tokenIn, msg.sender, tokenAmountIn);
+        _pushUnderlying(tokenOut, msg.sender, tokenAmountOut);
+
+        return (tokenAmountOut, spotPriceAfter);
+    }
+
+    function swapExactAmountOut(
+        address tokenIn,
+        uint maxAmountIn,
+        address tokenOut,
+        uint tokenAmountOut,
+        uint maxPrice
+    )
+        external
+        _logs_
+        _lock_
+        returns (uint tokenAmountIn, uint spotPriceAfter)
+    {
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        require(_publicSwap, "ERR_SWAP_NOT_PUBLIC");
+
+        Record storage inRecord = _records[address(tokenIn)];
+        Record storage outRecord = _records[address(tokenOut)];
+
+        require(tokenAmountOut <= bmul(outRecord.balance, MAX_OUT_RATIO), "ERR_MAX_OUT_RATIO");
+
+        uint spotPriceBefore = calcSpotPrice(
+                                    inRecord.balance,
+                                    inRecord.denorm,
+                                    outRecord.balance,
+                                    outRecord.denorm,
+                                    _swapFee
+                                );
+        require(spotPriceBefore <= maxPrice, "ERR_BAD_LIMIT_PRICE");
+
+        tokenAmountIn = calcInGivenOut(
+                            inRecord.balance,
+                            inRecord.denorm,
+                            outRecord.balance,
+                            outRecord.denorm,
+                            tokenAmountOut,
+                            _swapFee
+                        );
+        require(tokenAmountIn <= maxAmountIn, "ERR_LIMIT_IN");
+
+        inRecord.balance = badd(inRecord.balance, tokenAmountIn);
+        outRecord.balance = bsub(outRecord.balance, tokenAmountOut);
+
+        spotPriceAfter = calcSpotPrice(
+                                inRecord.balance,
+                                inRecord.denorm,
+                                outRecord.balance,
+                                outRecord.denorm,
+                                _swapFee
+                            );
+        require(spotPriceAfter >= spotPriceBefore, "ERR_MATH_APPROX");
+        require(spotPriceAfter <= maxPrice, "ERR_LIMIT_PRICE");
+        require(spotPriceBefore <= bdiv(tokenAmountIn, tokenAmountOut), "ERR_MATH_APPROX");
+
+        emit LOG_SWAP(msg.sender, tokenIn, tokenOut, tokenAmountIn, tokenAmountOut);
+
+        _pullUnderlying(tokenIn, msg.sender, tokenAmountIn);
+        _pushUnderlying(tokenOut, msg.sender, tokenAmountOut);
+
+        return (tokenAmountIn, spotPriceAfter);
+    }
+
+
+    function joinswapExternAmountIn(address tokenIn, uint tokenAmountIn, uint minPoolAmountOut)
+        external
+        _logs_
+        _lock_
+        returns (uint poolAmountOut)
+
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(tokenAmountIn <= bmul(_records[tokenIn].balance, MAX_IN_RATIO), "ERR_MAX_IN_RATIO");
+
+        Record storage inRecord = _records[tokenIn];
+
+        poolAmountOut = calcPoolOutGivenSingleIn(
+                            inRecord.balance,
+                            inRecord.denorm,
+                            _totalSupply,
+                            _totalWeight,
+                            tokenAmountIn,
+                            _swapFee
+                        );
+
+        require(poolAmountOut >= minPoolAmountOut, "ERR_LIMIT_OUT");
+
+        inRecord.balance = badd(inRecord.balance, tokenAmountIn);
+
+        emit LOG_JOIN(msg.sender, tokenIn, tokenAmountIn);
+
+        _mintPoolShare(poolAmountOut);
+        _pushPoolShare(msg.sender, poolAmountOut);
+        _pullUnderlying(tokenIn, msg.sender, tokenAmountIn);
+
+        return poolAmountOut;
+    }
+
+    function joinswapPoolAmountOut(address tokenIn, uint poolAmountOut, uint maxAmountIn)
+        external
+        _logs_
+        _lock_
+        returns (uint tokenAmountIn)
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+
+        Record storage inRecord = _records[tokenIn];
+
+        tokenAmountIn = calcSingleInGivenPoolOut(
+                            inRecord.balance,
+                            inRecord.denorm,
+                            _totalSupply,
+                            _totalWeight,
+                            poolAmountOut,
+                            _swapFee
+                        );
+
+        require(tokenAmountIn != 0, "ERR_MATH_APPROX");
+        require(tokenAmountIn <= maxAmountIn, "ERR_LIMIT_IN");
+
+        require(tokenAmountIn <= bmul(_records[tokenIn].balance, MAX_IN_RATIO), "ERR_MAX_IN_RATIO");
+
+        inRecord.balance = badd(inRecord.balance, tokenAmountIn);
+
+        emit LOG_JOIN(msg.sender, tokenIn, tokenAmountIn);
+
+        _mintPoolShare(poolAmountOut);
+        _pushPoolShare(msg.sender, poolAmountOut);
+        _pullUnderlying(tokenIn, msg.sender, tokenAmountIn);
+
+        return tokenAmountIn;
+    }
+
+    function exitswapPoolAmountIn(address tokenOut, uint poolAmountIn, uint minAmountOut)
+        external
+        _logs_
+        _lock_
+        returns (uint tokenAmountOut)
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+
+        Record storage outRecord = _records[tokenOut];
+
+        tokenAmountOut = calcSingleOutGivenPoolIn(
+                            outRecord.balance,
+                            outRecord.denorm,
+                            _totalSupply,
+                            _totalWeight,
+                            poolAmountIn,
+                            _swapFee
+                        );
+
+        require(tokenAmountOut >= minAmountOut, "ERR_LIMIT_OUT");
+
+        require(tokenAmountOut <= bmul(_records[tokenOut].balance, MAX_OUT_RATIO), "ERR_MAX_OUT_RATIO");
+
+        outRecord.balance = bsub(outRecord.balance, tokenAmountOut);
+
+        uint exitFee = bmul(poolAmountIn, EXIT_FEE);
+
+        emit LOG_EXIT(msg.sender, tokenOut, tokenAmountOut);
+
+        _pullPoolShare(msg.sender, poolAmountIn);
+        _burnPoolShare(bsub(poolAmountIn, exitFee));
+        _pushPoolShare(_factory, exitFee);
+        _pushUnderlying(tokenOut, msg.sender, tokenAmountOut);
+
+        return tokenAmountOut;
+    }
+
+    function exitswapExternAmountOut(address tokenOut, uint tokenAmountOut, uint maxPoolAmountIn)
+        external
+        _logs_
+        _lock_
+        returns (uint poolAmountIn)
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        require(tokenAmountOut <= bmul(_records[tokenOut].balance, MAX_OUT_RATIO), "ERR_MAX_OUT_RATIO");
+
+        Record storage outRecord = _records[tokenOut];
+
+        poolAmountIn = calcPoolInGivenSingleOut(
+                            outRecord.balance,
+                            outRecord.denorm,
+                            _totalSupply,
+                            _totalWeight,
+                            tokenAmountOut,
+                            _swapFee
+                        );
+
+        require(poolAmountIn != 0, "ERR_MATH_APPROX");
+        require(poolAmountIn <= maxPoolAmountIn, "ERR_LIMIT_IN");
+
+        outRecord.balance = bsub(outRecord.balance, tokenAmountOut);
+
+        uint exitFee = bmul(poolAmountIn, EXIT_FEE);
+
+        emit LOG_EXIT(msg.sender, tokenOut, tokenAmountOut);
+
+        _pullPoolShare(msg.sender, poolAmountIn);
+        _burnPoolShare(bsub(poolAmountIn, exitFee));
+        _pushPoolShare(_factory, exitFee);
+        _pushUnderlying(tokenOut, msg.sender, tokenAmountOut);
+
+        return poolAmountIn;
+    }
+
+
+    // ==
+    // 'Underlying' token-manipulation functions make external calls but are NOT locked
+    // You must `_lock_` or otherwise ensure reentry-safety
+
+    function _pullUnderlying(address erc20, address from, uint amount)
+        internal
+    {
+        bool xfer = IERC20(erc20).transferFrom(from, address(this), amount);
+        require(xfer, "ERR_ERC20_FALSE");
+    }
+
+    function _pushUnderlying(address erc20, address to, uint amount)
+        internal
+    {
+        bool xfer = IERC20(erc20).transfer(to, amount);
+        require(xfer, "ERR_ERC20_FALSE");
+    }
+
+    function _pullPoolShare(address from, uint amount)
+        internal
+    {
+        _pull(from, amount);
+    }
+
+    function _pushPoolShare(address to, uint amount)
+        internal
+    {
+        _push(to, amount);
+    }
+
+    function _mintPoolShare(uint amount)
+        internal
+    {
+        _mint(amount);
+    }
+
+    function _burnPoolShare(uint amount)
+        internal
+    {
+        _burn(amount);
+    }
+
+}

--- a/contracts/verify-bpool-impl/Address.sol
+++ b/contracts/verify-bpool-impl/Address.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: value }(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data, string memory errorMessage) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    function _verifyCallResult(bool success, bytes memory returndata, string memory errorMessage) private pure returns(bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}

--- a/contracts/verify-bpool-impl/BColor.sol
+++ b/contracts/verify-bpool-impl/BColor.sol
@@ -1,0 +1,28 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+abstract contract BColor {
+    function getColor()
+        external virtual view
+        returns (bytes32);
+}
+
+contract BBronze is BColor {
+    function getColor()
+        external override view
+        returns (bytes32) {
+            return bytes32("BRONZE");
+        }
+}

--- a/contracts/verify-bpool-impl/BConst.sol
+++ b/contracts/verify-bpool-impl/BConst.sol
@@ -1,0 +1,41 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "./BColor.sol";
+
+contract BConst is BBronze {
+    uint public constant BONE              = 10**18;
+
+    uint public constant MIN_BOUND_TOKENS  = 2;
+    uint public constant MAX_BOUND_TOKENS  = 8;
+
+    uint public constant MIN_FEE           = BONE / 10**6;
+    uint public constant MAX_FEE           = BONE / 10;
+    uint public constant EXIT_FEE          = 0;
+
+    uint public constant MIN_WEIGHT        = BONE;
+    uint public constant MAX_WEIGHT        = BONE * 50;
+    uint public constant MAX_TOTAL_WEIGHT  = BONE * 50;
+    uint public constant MIN_BALANCE       = BONE / 10**12;
+
+    uint public constant INIT_POOL_SUPPLY  = BONE * 100;
+
+    uint public constant MIN_BPOW_BASE     = 1 wei;
+    uint public constant MAX_BPOW_BASE     = (2 * BONE) - 1 wei;
+    uint public constant BPOW_PRECISION    = BONE / 10**10;
+
+    uint public constant MAX_IN_RATIO      = BONE / 2;
+    uint public constant MAX_OUT_RATIO     = (BONE / 3) + 1 wei;
+}

--- a/contracts/verify-bpool-impl/BMath.sol
+++ b/contracts/verify-bpool-impl/BMath.sol
@@ -1,0 +1,271 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "./BNum.sol";
+
+contract BMath is BBronze, BConst, BNum {
+    /**********************************************************************************************
+    // calcSpotPrice                                                                             //
+    // sP = spotPrice                                                                            //
+    // bI = tokenBalanceIn                ( bI / wI )         1                                  //
+    // bO = tokenBalanceOut         sP =  -----------  *  ----------                             //
+    // wI = tokenWeightIn                 ( bO / wO )     ( 1 - sF )                             //
+    // wO = tokenWeightOut                                                                       //
+    // sF = swapFee                                                                              //
+    **********************************************************************************************/
+    function calcSpotPrice(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint swapFee
+    )
+        public pure
+        returns (uint spotPrice)
+    {
+        uint numer = bdiv(tokenBalanceIn, tokenWeightIn);
+        uint denom = bdiv(tokenBalanceOut, tokenWeightOut);
+        uint ratio = bdiv(numer, denom);
+        uint scale = bdiv(BONE, bsub(BONE, swapFee));
+        return  (spotPrice = bmul(ratio, scale));
+    }
+
+    /**********************************************************************************************
+    // calcOutGivenIn                                                                            //
+    // aO = tokenAmountOut                                                                       //
+    // bO = tokenBalanceOut                                                                      //
+    // bI = tokenBalanceIn              /      /            bI             \    (wI / wO) \      //
+    // aI = tokenAmountIn    aO = bO * |  1 - | --------------------------  | ^            |     //
+    // wI = tokenWeightIn               \      \ ( bI + ( aI * ( 1 - sF )) /              /      //
+    // wO = tokenWeightOut                                                                       //
+    // sF = swapFee                                                                              //
+    **********************************************************************************************/
+    function calcOutGivenIn(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint tokenAmountIn,
+        uint swapFee
+    )
+        public pure
+        returns (uint tokenAmountOut)
+    {
+        uint weightRatio = bdiv(tokenWeightIn, tokenWeightOut);
+        uint adjustedIn = bsub(BONE, swapFee);
+        adjustedIn = bmul(tokenAmountIn, adjustedIn);
+        uint y = bdiv(tokenBalanceIn, badd(tokenBalanceIn, adjustedIn));
+        uint foo = bpow(y, weightRatio);
+        uint bar = bsub(BONE, foo);
+        tokenAmountOut = bmul(tokenBalanceOut, bar);
+        return tokenAmountOut;
+    }
+
+    /**********************************************************************************************
+    // calcInGivenOut                                                                            //
+    // aI = tokenAmountIn                                                                        //
+    // bO = tokenBalanceOut               /  /     bO      \    (wO / wI)      \                 //
+    // bI = tokenBalanceIn          bI * |  | ------------  | ^            - 1  |                //
+    // aO = tokenAmountOut    aI =        \  \ ( bO - aO ) /                   /                 //
+    // wI = tokenWeightIn           --------------------------------------------                 //
+    // wO = tokenWeightOut                          ( 1 - sF )                                   //
+    // sF = swapFee                                                                              //
+    **********************************************************************************************/
+    function calcInGivenOut(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint tokenAmountOut,
+        uint swapFee
+    )
+        public pure
+        returns (uint tokenAmountIn)
+    {
+        uint weightRatio = bdiv(tokenWeightOut, tokenWeightIn);
+        uint diff = bsub(tokenBalanceOut, tokenAmountOut);
+        uint y = bdiv(tokenBalanceOut, diff);
+        uint foo = bpow(y, weightRatio);
+        foo = bsub(foo, BONE);
+        tokenAmountIn = bsub(BONE, swapFee);
+        tokenAmountIn = bdiv(bmul(tokenBalanceIn, foo), tokenAmountIn);
+        return tokenAmountIn;
+    }
+
+    /**********************************************************************************************
+    // calcPoolOutGivenSingleIn                                                                  //
+    // pAo = poolAmountOut         /                                              \              //
+    // tAi = tokenAmountIn        ///      /     //    wI \      \\       \     wI \             //
+    // wI = tokenWeightIn        //| tAi *| 1 - || 1 - --  | * sF || + tBi \    --  \            //
+    // tW = totalWeight     pAo=||  \      \     \\    tW /      //         | ^ tW   | * pS - pS //
+    // tBi = tokenBalanceIn      \\  ------------------------------------- /        /            //
+    // pS = poolSupply            \\                    tBi               /        /             //
+    // sF = swapFee                \                                              /              //
+    **********************************************************************************************/
+    function calcPoolOutGivenSingleIn(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint poolSupply,
+        uint totalWeight,
+        uint tokenAmountIn,
+        uint swapFee
+    )
+        public pure
+        returns (uint poolAmountOut)
+    {
+        // Charge the trading fee for the proportion of tokenAi
+        // which is implicitly traded to the other pool tokens.
+        // That proportion is (1- weightTokenIn)
+        // tokenAiAfterFee = tAi * (1 - (1-weightTi) * poolFee);
+        uint normalizedWeight = bdiv(tokenWeightIn, totalWeight);
+        uint zaz = bmul(bsub(BONE, normalizedWeight), swapFee);
+        uint tokenAmountInAfterFee = bmul(tokenAmountIn, bsub(BONE, zaz));
+
+        uint newTokenBalanceIn = badd(tokenBalanceIn, tokenAmountInAfterFee);
+        uint tokenInRatio = bdiv(newTokenBalanceIn, tokenBalanceIn);
+
+        // uint newPoolSupply = (ratioTi ^ weightTi) * poolSupply;
+        uint poolRatio = bpow(tokenInRatio, normalizedWeight);
+        uint newPoolSupply = bmul(poolRatio, poolSupply);
+        poolAmountOut = bsub(newPoolSupply, poolSupply);
+        return poolAmountOut;
+    }
+
+    /**********************************************************************************************
+    // calcSingleInGivenPoolOut                                                                  //
+    // tAi = tokenAmountIn              //(pS + pAo)\     /    1    \\                           //
+    // pS = poolSupply                 || ---------  | ^ | --------- || * bI - bI                //
+    // pAo = poolAmountOut              \\    pS    /     \(wI / tW)//                           //
+    // bI = balanceIn          tAi =  --------------------------------------------               //
+    // wI = weightIn                              /      wI  \                                   //
+    // tW = totalWeight                          |  1 - ----  |  * sF                            //
+    // sF = swapFee                               \      tW  /                                   //
+    **********************************************************************************************/
+    function calcSingleInGivenPoolOut(
+        uint tokenBalanceIn,
+        uint tokenWeightIn,
+        uint poolSupply,
+        uint totalWeight,
+        uint poolAmountOut,
+        uint swapFee
+    )
+        public pure
+        returns (uint tokenAmountIn)
+    {
+        uint normalizedWeight = bdiv(tokenWeightIn, totalWeight);
+        uint newPoolSupply = badd(poolSupply, poolAmountOut);
+        uint poolRatio = bdiv(newPoolSupply, poolSupply);
+
+        //uint newBalTi = poolRatio^(1/weightTi) * balTi;
+        uint boo = bdiv(BONE, normalizedWeight);
+        uint tokenInRatio = bpow(poolRatio, boo);
+        uint newTokenBalanceIn = bmul(tokenInRatio, tokenBalanceIn);
+        uint tokenAmountInAfterFee = bsub(newTokenBalanceIn, tokenBalanceIn);
+        // Do reverse order of fees charged in joinswap_ExternAmountIn, this way
+        //     ``` pAo == joinswap_ExternAmountIn(Ti, joinswap_PoolAmountOut(pAo, Ti)) ```
+        //uint tAi = tAiAfterFee / (1 - (1-weightTi) * swapFee) ;
+        uint zar = bmul(bsub(BONE, normalizedWeight), swapFee);
+        tokenAmountIn = bdiv(tokenAmountInAfterFee, bsub(BONE, zar));
+        return tokenAmountIn;
+    }
+
+    /**********************************************************************************************
+    // calcSingleOutGivenPoolIn                                                                  //
+    // tAo = tokenAmountOut            /      /                                             \\   //
+    // bO = tokenBalanceOut           /      // pS - (pAi * (1 - eF)) \     /    1    \      \\  //
+    // pAi = poolAmountIn            | bO - || ----------------------- | ^ | --------- | * b0 || //
+    // ps = poolSupply                \      \\          pS           /     \(wO / tW)/      //  //
+    // wI = tokenWeightIn      tAo =   \      \                                             //   //
+    // tW = totalWeight                    /     /      wO \       \                             //
+    // sF = swapFee                    *  | 1 - |  1 - ---- | * sF  |                            //
+    // eF = exitFee                        \     \      tW /       /                             //
+    **********************************************************************************************/
+    function calcSingleOutGivenPoolIn(
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint poolSupply,
+        uint totalWeight,
+        uint poolAmountIn,
+        uint swapFee
+    )
+        public pure
+        returns (uint tokenAmountOut)
+    {
+        uint normalizedWeight = bdiv(tokenWeightOut, totalWeight);
+        // charge exit fee on the pool token side
+        // pAiAfterExitFee = pAi*(1-exitFee)
+        uint poolAmountInAfterExitFee = bmul(poolAmountIn, bsub(BONE, EXIT_FEE));
+        uint newPoolSupply = bsub(poolSupply, poolAmountInAfterExitFee);
+        uint poolRatio = bdiv(newPoolSupply, poolSupply);
+
+        // newBalTo = poolRatio^(1/weightTo) * balTo;
+        uint tokenOutRatio = bpow(poolRatio, bdiv(BONE, normalizedWeight));
+        uint newTokenBalanceOut = bmul(tokenOutRatio, tokenBalanceOut);
+
+        uint tokenAmountOutBeforeSwapFee = bsub(tokenBalanceOut, newTokenBalanceOut);
+
+        // charge swap fee on the output token side
+        //uint tAo = tAoBeforeSwapFee * (1 - (1-weightTo) * swapFee)
+        uint zaz = bmul(bsub(BONE, normalizedWeight), swapFee);
+        tokenAmountOut = bmul(tokenAmountOutBeforeSwapFee, bsub(BONE, zaz));
+        return tokenAmountOut;
+    }
+
+    /**********************************************************************************************
+    // calcPoolInGivenSingleOut                                                                  //
+    // pAi = poolAmountIn               // /               tAo             \\     / wO \     \   //
+    // bO = tokenBalanceOut            // | bO - -------------------------- |\   | ---- |     \  //
+    // tAo = tokenAmountOut      pS - ||   \     1 - ((1 - (tO / tW)) * sF)/  | ^ \ tW /  * pS | //
+    // ps = poolSupply                 \\ -----------------------------------/                /  //
+    // wO = tokenWeightOut  pAi =       \\               bO                 /                /   //
+    // tW = totalWeight           -------------------------------------------------------------  //
+    // sF = swapFee                                        ( 1 - eF )                            //
+    // eF = exitFee                                                                              //
+    **********************************************************************************************/
+    function calcPoolInGivenSingleOut(
+        uint tokenBalanceOut,
+        uint tokenWeightOut,
+        uint poolSupply,
+        uint totalWeight,
+        uint tokenAmountOut,
+        uint swapFee
+    )
+        public pure
+        returns (uint poolAmountIn)
+    {
+
+        // charge swap fee on the output token side
+        uint normalizedWeight = bdiv(tokenWeightOut, totalWeight);
+        //uint tAoBeforeSwapFee = tAo / (1 - (1-weightTo) * swapFee) ;
+        uint zoo = bsub(BONE, normalizedWeight);
+        uint zar = bmul(zoo, swapFee);
+        uint tokenAmountOutBeforeSwapFee = bdiv(tokenAmountOut, bsub(BONE, zar));
+
+        uint newTokenBalanceOut = bsub(tokenBalanceOut, tokenAmountOutBeforeSwapFee);
+        uint tokenOutRatio = bdiv(newTokenBalanceOut, tokenBalanceOut);
+
+        //uint newPoolSupply = (ratioTo ^ weightTo) * poolSupply;
+        uint poolRatio = bpow(tokenOutRatio, normalizedWeight);
+        uint newPoolSupply = bmul(poolRatio, poolSupply);
+        uint poolAmountInAfterExitFee = bsub(poolSupply, newPoolSupply);
+
+        // charge exit fee on the pool token side
+        // pAi = pAiAfterExitFee/(1-exitFee)
+        poolAmountIn = bdiv(poolAmountInAfterExitFee, bsub(BONE, EXIT_FEE));
+        return poolAmountIn;
+    }
+
+
+}

--- a/contracts/verify-bpool-impl/BNum.sol
+++ b/contracts/verify-bpool-impl/BNum.sol
@@ -1,0 +1,163 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "./BConst.sol";
+
+contract BNum is BConst {
+
+    function btoi(uint a)
+        internal pure
+        returns (uint)
+    {
+        return a / BONE;
+    }
+
+    function bfloor(uint a)
+        internal pure
+        returns (uint)
+    {
+        return btoi(a) * BONE;
+    }
+
+    function badd(uint a, uint b)
+        internal pure
+        returns (uint)
+    {
+        uint c = a + b;
+        require(c >= a, "ERR_ADD_OVERFLOW");
+        return c;
+    }
+
+    function bsub(uint a, uint b)
+        internal pure
+        returns (uint)
+    {
+        (uint c, bool flag) = bsubSign(a, b);
+        require(!flag, "ERR_SUB_UNDERFLOW");
+        return c;
+    }
+
+    function bsubSign(uint a, uint b)
+        internal pure
+        returns (uint, bool)
+    {
+        if (a >= b) {
+            return (a - b, false);
+        } else {
+            return (b - a, true);
+        }
+    }
+
+    function bmul(uint a, uint b)
+        internal pure
+        returns (uint)
+    {
+        uint c0 = a * b;
+        require(a == 0 || c0 / a == b, "ERR_MUL_OVERFLOW");
+        uint c1 = c0 + (BONE / 2);
+        require(c1 >= c0, "ERR_MUL_OVERFLOW");
+        uint c2 = c1 / BONE;
+        return c2;
+    }
+
+    function bdiv(uint a, uint b)
+        internal pure
+        returns (uint)
+    {
+        require(b != 0, "ERR_DIV_ZERO");
+        uint c0 = a * BONE;
+        require(a == 0 || c0 / a == BONE, "ERR_DIV_INTERNAL"); // bmul overflow
+        uint c1 = c0 + (b / 2);
+        require(c1 >= c0, "ERR_DIV_INTERNAL"); //  badd require
+        uint c2 = c1 / b;
+        return c2;
+    }
+
+    // DSMath.wpow
+    function bpowi(uint a, uint n)
+        internal pure
+        returns (uint)
+    {
+        uint z = n % 2 != 0 ? a : BONE;
+
+        for (n /= 2; n != 0; n /= 2) {
+            a = bmul(a, a);
+
+            if (n % 2 != 0) {
+                z = bmul(z, a);
+            }
+        }
+        return z;
+    }
+
+    // Compute b^(e.w) by splitting it into (b^e)*(b^0.w).
+    // Use `bpowi` for `b^e` and `bpowK` for k iterations
+    // of approximation of b^0.w
+    function bpow(uint base, uint exp)
+        internal pure
+        returns (uint)
+    {
+        require(base >= MIN_BPOW_BASE, "ERR_BPOW_BASE_TOO_LOW");
+        require(base <= MAX_BPOW_BASE, "ERR_BPOW_BASE_TOO_HIGH");
+
+        uint whole  = bfloor(exp);
+        uint remain = bsub(exp, whole);
+
+        uint wholePow = bpowi(base, btoi(whole));
+
+        if (remain == 0) {
+            return wholePow;
+        }
+
+        uint partialResult = bpowApprox(base, remain, BPOW_PRECISION);
+        return bmul(wholePow, partialResult);
+    }
+
+    function bpowApprox(uint base, uint exp, uint precision)
+        internal pure
+        returns (uint)
+    {
+        // term 0:
+        uint a     = exp;
+        (uint x, bool xneg)  = bsubSign(base, BONE);
+        uint term = BONE;
+        uint sum   = term;
+        bool negative = false;
+
+
+        // term(k) = numer / denom
+        //         = (product(a - i - 1, i=1-->k) * x^k) / (k!)
+        // each iteration, multiply previous term by (a-(k-1)) * x / k
+        // continue until term is less than precision
+        for (uint i = 1; term >= precision; i++) {
+            uint bigK = i * BONE;
+            (uint c, bool cneg) = bsubSign(a, bsub(bigK, BONE));
+            term = bmul(term, bmul(c, x));
+            term = bdiv(term, bigK);
+            if (term == 0) break;
+
+            if (xneg) negative = !negative;
+            if (cneg) negative = !negative;
+            if (negative) {
+                sum = bsub(sum, term);
+            } else {
+                sum = badd(sum, term);
+            }
+        }
+
+        return sum;
+    }
+
+}

--- a/contracts/verify-bpool-impl/BPool.sol
+++ b/contracts/verify-bpool-impl/BPool.sol
@@ -1,0 +1,740 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "./BToken.sol";
+import "./BMath.sol";
+
+contract BPool is BBronze, BToken, BMath {
+
+    struct Record {
+        bool bound;   // is token bound to pool
+        uint index;   // private
+        uint denorm;  // denormalized weight
+        uint balance;
+    }
+
+    event LOG_SWAP(
+        address indexed caller,
+        address indexed tokenIn,
+        address indexed tokenOut,
+        uint256         tokenAmountIn,
+        uint256         tokenAmountOut
+    );
+
+    event LOG_JOIN(
+        address indexed caller,
+        address indexed tokenIn,
+        uint256         tokenAmountIn
+    );
+
+    event LOG_EXIT(
+        address indexed caller,
+        address indexed tokenOut,
+        uint256         tokenAmountOut
+    );
+
+    event LOG_CALL(
+        bytes4  indexed sig,
+        address indexed caller,
+        bytes           data
+    ) anonymous;
+
+    modifier _logs_() {
+        emit LOG_CALL(msg.sig, msg.sender, msg.data);
+        _;
+    }
+
+    modifier _lock_() {
+        require(!_mutex, "ERR_REENTRY");
+        _mutex = true;
+        _;
+        _mutex = false;
+    }
+
+    modifier _viewlock_() {
+        require(!_mutex, "ERR_REENTRY");
+        _;
+    }
+
+    bool private _mutex;
+
+    address private _factory;    // BFactory address to push token exitFee to
+    address private _controller; // has CONTROL role
+    bool private _publicSwap; // true if PUBLIC can call SWAP functions
+
+    // `setSwapFee` and `finalize` require CONTROL
+    // `finalize` sets `PUBLIC can SWAP`, `PUBLIC can JOIN`
+    uint private _swapFee;
+    bool private _finalized;
+
+    address[] private _tokens;
+    mapping(address=>Record) private  _records;
+    uint private _totalWeight;
+
+    function initialize() public initializer {
+        _controller = msg.sender;
+        _factory = msg.sender;
+        _swapFee = MIN_FEE;
+        _publicSwap = false;
+        _finalized = false;
+        __BToken_init_unchained();
+    }
+
+    function isPublicSwap()
+        external view
+        returns (bool)
+    {
+        return _publicSwap;
+    }
+
+    function isFinalized()
+        external view
+        returns (bool)
+    {
+        return _finalized;
+    }
+
+    function isBound(address t)
+        external view
+        returns (bool)
+    {
+        return _records[t].bound;
+    }
+
+    function getNumTokens()
+        external view
+        returns (uint)
+    {
+        return _tokens.length;
+    }
+
+    function getCurrentTokens()
+        external view _viewlock_
+        returns (address[] memory tokens)
+    {
+        return _tokens;
+    }
+
+    function getFinalTokens()
+        external view
+        _viewlock_
+        returns (address[] memory tokens)
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        return _tokens;
+    }
+
+    function getDenormalizedWeight(address token)
+        external view
+        _viewlock_
+        returns (uint)
+    {
+
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        return _records[token].denorm;
+    }
+
+    function getTotalDenormalizedWeight()
+        external view
+        _viewlock_
+        returns (uint)
+    {
+        return _totalWeight;
+    }
+
+    function getNormalizedWeight(address token)
+        external view
+        _viewlock_
+        returns (uint)
+    {
+
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        uint denorm = _records[token].denorm;
+        return bdiv(denorm, _totalWeight);
+    }
+
+    function getBalance(address token)
+        external view
+        _viewlock_
+        returns (uint)
+    {
+
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        return _records[token].balance;
+    }
+
+    function getSwapFee()
+        external view
+        _viewlock_
+        returns (uint)
+    {
+        return _swapFee;
+    }
+
+    function getController()
+        external view
+        _viewlock_
+        returns (address)
+    {
+        return _controller;
+    }
+
+    function setSwapFee(uint swapFee)
+        external
+        _logs_
+        _lock_
+    {
+        require(!_finalized, "ERR_IS_FINALIZED");
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(swapFee >= MIN_FEE, "ERR_MIN_FEE");
+        require(swapFee <= MAX_FEE, "ERR_MAX_FEE");
+        _swapFee = swapFee;
+    }
+
+    function setController(address manager)
+        external
+        _logs_
+        _lock_
+    {
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        _controller = manager;
+    }
+
+    function setPublicSwap(bool public_)
+        external
+        _logs_
+        _lock_
+    {
+        require(!_finalized, "ERR_IS_FINALIZED");
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        _publicSwap = public_;
+    }
+
+    function finalize()
+        external
+        _logs_
+        _lock_
+    {
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(!_finalized, "ERR_IS_FINALIZED");
+        require(_tokens.length >= MIN_BOUND_TOKENS, "ERR_MIN_TOKENS");
+
+        _finalized = true;
+        _publicSwap = true;
+
+        _mintPoolShare(INIT_POOL_SUPPLY);
+        _pushPoolShare(msg.sender, INIT_POOL_SUPPLY);
+    }
+
+
+    function bind(address token, uint balance, uint denorm)
+        external
+        _logs_
+        // _lock_  Bind does not lock because it jumps to `rebind`, which does
+    {
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(!_records[token].bound, "ERR_IS_BOUND");
+        require(!_finalized, "ERR_IS_FINALIZED");
+
+        require(_tokens.length < MAX_BOUND_TOKENS, "ERR_MAX_TOKENS");
+
+        _records[token] = Record({
+            bound: true,
+            index: _tokens.length,
+            denorm: 0,    // balance and denorm will be validated
+            balance: 0   // and set by `rebind`
+        });
+        _tokens.push(token);
+        rebind(token, balance, denorm);
+    }
+
+    function rebind(address token, uint balance, uint denorm)
+        public
+        _logs_
+        _lock_
+    {
+
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        require(!_finalized, "ERR_IS_FINALIZED");
+
+        require(denorm >= MIN_WEIGHT, "ERR_MIN_WEIGHT");
+        require(denorm <= MAX_WEIGHT, "ERR_MAX_WEIGHT");
+        require(balance >= MIN_BALANCE, "ERR_MIN_BALANCE");
+
+        // Adjust the denorm and totalWeight
+        uint oldWeight = _records[token].denorm;
+        if (denorm > oldWeight) {
+            _totalWeight = badd(_totalWeight, bsub(denorm, oldWeight));
+            require(_totalWeight <= MAX_TOTAL_WEIGHT, "ERR_MAX_TOTAL_WEIGHT");
+        } else if (denorm < oldWeight) {
+            _totalWeight = bsub(_totalWeight, bsub(oldWeight, denorm));
+        }
+        _records[token].denorm = denorm;
+
+        // Adjust the balance record and actual token balance
+        uint oldBalance = _records[token].balance;
+        _records[token].balance = balance;
+        if (balance > oldBalance) {
+            _pullUnderlying(token, msg.sender, bsub(balance, oldBalance));
+        } else if (balance < oldBalance) {
+            // In this case liquidity is being withdrawn, so charge EXIT_FEE
+            uint tokenBalanceWithdrawn = bsub(oldBalance, balance);
+            uint tokenExitFee = bmul(tokenBalanceWithdrawn, EXIT_FEE);
+            _pushUnderlying(token, msg.sender, bsub(tokenBalanceWithdrawn, tokenExitFee));
+            _pushUnderlying(token, _factory, tokenExitFee);
+        }
+    }
+
+    function unbind(address token)
+        external
+        _logs_
+        _lock_
+    {
+
+        require(msg.sender == _controller, "ERR_NOT_CONTROLLER");
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        require(!_finalized, "ERR_IS_FINALIZED");
+
+        uint tokenBalance = _records[token].balance;
+        uint tokenExitFee = bmul(tokenBalance, EXIT_FEE);
+
+        _totalWeight = bsub(_totalWeight, _records[token].denorm);
+
+        // Swap the token-to-unbind with the last token,
+        // then delete the last token
+        uint index = _records[token].index;
+        uint last = _tokens.length - 1;
+        _tokens[index] = _tokens[last];
+        _records[_tokens[index]].index = index;
+        _tokens.pop();
+        _records[token] = Record({
+            bound: false,
+            index: 0,
+            denorm: 0,
+            balance: 0
+        });
+
+        _pushUnderlying(token, msg.sender, bsub(tokenBalance, tokenExitFee));
+        _pushUnderlying(token, _factory, tokenExitFee);
+    }
+
+    // Absorb any tokens that have been sent to this contract into the pool
+    function gulp(address token)
+        external
+        _logs_
+        _lock_
+    {
+        require(_records[token].bound, "ERR_NOT_BOUND");
+        _records[token].balance = IERC20(token).balanceOf(address(this));
+    }
+
+    function getSpotPrice(address tokenIn, address tokenOut)
+        external view
+        _viewlock_
+        returns (uint spotPrice)
+    {
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        Record storage inRecord = _records[tokenIn];
+        Record storage outRecord = _records[tokenOut];
+        return calcSpotPrice(inRecord.balance, inRecord.denorm, outRecord.balance, outRecord.denorm, _swapFee);
+    }
+
+    function getSpotPriceSansFee(address tokenIn, address tokenOut)
+        external view
+        _viewlock_
+        returns (uint spotPrice)
+    {
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        Record storage inRecord = _records[tokenIn];
+        Record storage outRecord = _records[tokenOut];
+        return calcSpotPrice(inRecord.balance, inRecord.denorm, outRecord.balance, outRecord.denorm, 0);
+    }
+
+    function joinPool(uint poolAmountOut, uint[] calldata maxAmountsIn)
+        external
+        _logs_
+        _lock_
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+
+        uint poolTotal = totalSupply();
+        uint ratio = bdiv(poolAmountOut, poolTotal);
+        require(ratio != 0, "ERR_MATH_APPROX");
+
+        for (uint i = 0; i < _tokens.length; i++) {
+            address t = _tokens[i];
+            uint bal = _records[t].balance;
+            uint tokenAmountIn = bmul(ratio, bal);
+            require(tokenAmountIn != 0, "ERR_MATH_APPROX");
+            require(tokenAmountIn <= maxAmountsIn[i], "ERR_LIMIT_IN");
+            _records[t].balance = badd(_records[t].balance, tokenAmountIn);
+            emit LOG_JOIN(msg.sender, t, tokenAmountIn);
+            _pullUnderlying(t, msg.sender, tokenAmountIn);
+        }
+        _mintPoolShare(poolAmountOut);
+        _pushPoolShare(msg.sender, poolAmountOut);
+    }
+
+    function exitPool(uint poolAmountIn, uint[] calldata minAmountsOut)
+        external
+        _logs_
+        _lock_
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+
+        uint poolTotal = totalSupply();
+        uint exitFee = bmul(poolAmountIn, EXIT_FEE);
+        uint pAiAfterExitFee = bsub(poolAmountIn, exitFee);
+        uint ratio = bdiv(pAiAfterExitFee, poolTotal);
+        require(ratio != 0, "ERR_MATH_APPROX");
+
+        _pullPoolShare(msg.sender, poolAmountIn);
+        _pushPoolShare(_factory, exitFee);
+        _burnPoolShare(pAiAfterExitFee);
+
+        for (uint i = 0; i < _tokens.length; i++) {
+            address t = _tokens[i];
+            uint bal = _records[t].balance;
+            uint tokenAmountOut = bmul(ratio, bal);
+            require(tokenAmountOut != 0, "ERR_MATH_APPROX");
+            require(tokenAmountOut >= minAmountsOut[i], "ERR_LIMIT_OUT");
+            _records[t].balance = bsub(_records[t].balance, tokenAmountOut);
+            emit LOG_EXIT(msg.sender, t, tokenAmountOut);
+            _pushUnderlying(t, msg.sender, tokenAmountOut);
+        }
+
+    }
+
+
+    function swapExactAmountIn(
+        address tokenIn,
+        uint tokenAmountIn,
+        address tokenOut,
+        uint minAmountOut,
+        uint maxPrice
+    )
+        external
+        _logs_
+        _lock_
+        returns (uint tokenAmountOut, uint spotPriceAfter)
+    {
+
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        require(_publicSwap, "ERR_SWAP_NOT_PUBLIC");
+
+        Record storage inRecord = _records[address(tokenIn)];
+        Record storage outRecord = _records[address(tokenOut)];
+
+        require(tokenAmountIn <= bmul(inRecord.balance, MAX_IN_RATIO), "ERR_MAX_IN_RATIO");
+
+        uint spotPriceBefore = calcSpotPrice(
+                                    inRecord.balance,
+                                    inRecord.denorm,
+                                    outRecord.balance,
+                                    outRecord.denorm,
+                                    _swapFee
+                                );
+        require(spotPriceBefore <= maxPrice, "ERR_BAD_LIMIT_PRICE");
+
+        tokenAmountOut = calcOutGivenIn(
+                            inRecord.balance,
+                            inRecord.denorm,
+                            outRecord.balance,
+                            outRecord.denorm,
+                            tokenAmountIn,
+                            _swapFee
+                        );
+        require(tokenAmountOut >= minAmountOut, "ERR_LIMIT_OUT");
+
+        inRecord.balance = badd(inRecord.balance, tokenAmountIn);
+        outRecord.balance = bsub(outRecord.balance, tokenAmountOut);
+
+        spotPriceAfter = calcSpotPrice(
+                                inRecord.balance,
+                                inRecord.denorm,
+                                outRecord.balance,
+                                outRecord.denorm,
+                                _swapFee
+                            );
+        require(spotPriceAfter >= spotPriceBefore, "ERR_MATH_APPROX");
+        require(spotPriceAfter <= maxPrice, "ERR_LIMIT_PRICE");
+        require(spotPriceBefore <= bdiv(tokenAmountIn, tokenAmountOut), "ERR_MATH_APPROX");
+
+        emit LOG_SWAP(msg.sender, tokenIn, tokenOut, tokenAmountIn, tokenAmountOut);
+
+        _pullUnderlying(tokenIn, msg.sender, tokenAmountIn);
+        _pushUnderlying(tokenOut, msg.sender, tokenAmountOut);
+
+        return (tokenAmountOut, spotPriceAfter);
+    }
+
+    function swapExactAmountOut(
+        address tokenIn,
+        uint maxAmountIn,
+        address tokenOut,
+        uint tokenAmountOut,
+        uint maxPrice
+    )
+        external
+        _logs_
+        _lock_
+        returns (uint tokenAmountIn, uint spotPriceAfter)
+    {
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        require(_publicSwap, "ERR_SWAP_NOT_PUBLIC");
+
+        Record storage inRecord = _records[address(tokenIn)];
+        Record storage outRecord = _records[address(tokenOut)];
+
+        require(tokenAmountOut <= bmul(outRecord.balance, MAX_OUT_RATIO), "ERR_MAX_OUT_RATIO");
+
+        uint spotPriceBefore = calcSpotPrice(
+                                    inRecord.balance,
+                                    inRecord.denorm,
+                                    outRecord.balance,
+                                    outRecord.denorm,
+                                    _swapFee
+                                );
+        require(spotPriceBefore <= maxPrice, "ERR_BAD_LIMIT_PRICE");
+
+        tokenAmountIn = calcInGivenOut(
+                            inRecord.balance,
+                            inRecord.denorm,
+                            outRecord.balance,
+                            outRecord.denorm,
+                            tokenAmountOut,
+                            _swapFee
+                        );
+        require(tokenAmountIn <= maxAmountIn, "ERR_LIMIT_IN");
+
+        inRecord.balance = badd(inRecord.balance, tokenAmountIn);
+        outRecord.balance = bsub(outRecord.balance, tokenAmountOut);
+
+        spotPriceAfter = calcSpotPrice(
+                                inRecord.balance,
+                                inRecord.denorm,
+                                outRecord.balance,
+                                outRecord.denorm,
+                                _swapFee
+                            );
+        require(spotPriceAfter >= spotPriceBefore, "ERR_MATH_APPROX");
+        require(spotPriceAfter <= maxPrice, "ERR_LIMIT_PRICE");
+        require(spotPriceBefore <= bdiv(tokenAmountIn, tokenAmountOut), "ERR_MATH_APPROX");
+
+        emit LOG_SWAP(msg.sender, tokenIn, tokenOut, tokenAmountIn, tokenAmountOut);
+
+        _pullUnderlying(tokenIn, msg.sender, tokenAmountIn);
+        _pushUnderlying(tokenOut, msg.sender, tokenAmountOut);
+
+        return (tokenAmountIn, spotPriceAfter);
+    }
+
+
+    function joinswapExternAmountIn(address tokenIn, uint tokenAmountIn, uint minPoolAmountOut)
+        external
+        _logs_
+        _lock_
+        returns (uint poolAmountOut)
+
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+        require(tokenAmountIn <= bmul(_records[tokenIn].balance, MAX_IN_RATIO), "ERR_MAX_IN_RATIO");
+
+        Record storage inRecord = _records[tokenIn];
+
+        poolAmountOut = calcPoolOutGivenSingleIn(
+                            inRecord.balance,
+                            inRecord.denorm,
+                            _totalSupply,
+                            _totalWeight,
+                            tokenAmountIn,
+                            _swapFee
+                        );
+
+        require(poolAmountOut >= minPoolAmountOut, "ERR_LIMIT_OUT");
+
+        inRecord.balance = badd(inRecord.balance, tokenAmountIn);
+
+        emit LOG_JOIN(msg.sender, tokenIn, tokenAmountIn);
+
+        _mintPoolShare(poolAmountOut);
+        _pushPoolShare(msg.sender, poolAmountOut);
+        _pullUnderlying(tokenIn, msg.sender, tokenAmountIn);
+
+        return poolAmountOut;
+    }
+
+    function joinswapPoolAmountOut(address tokenIn, uint poolAmountOut, uint maxAmountIn)
+        external
+        _logs_
+        _lock_
+        returns (uint tokenAmountIn)
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        require(_records[tokenIn].bound, "ERR_NOT_BOUND");
+
+        Record storage inRecord = _records[tokenIn];
+
+        tokenAmountIn = calcSingleInGivenPoolOut(
+                            inRecord.balance,
+                            inRecord.denorm,
+                            _totalSupply,
+                            _totalWeight,
+                            poolAmountOut,
+                            _swapFee
+                        );
+
+        require(tokenAmountIn != 0, "ERR_MATH_APPROX");
+        require(tokenAmountIn <= maxAmountIn, "ERR_LIMIT_IN");
+
+        require(tokenAmountIn <= bmul(_records[tokenIn].balance, MAX_IN_RATIO), "ERR_MAX_IN_RATIO");
+
+        inRecord.balance = badd(inRecord.balance, tokenAmountIn);
+
+        emit LOG_JOIN(msg.sender, tokenIn, tokenAmountIn);
+
+        _mintPoolShare(poolAmountOut);
+        _pushPoolShare(msg.sender, poolAmountOut);
+        _pullUnderlying(tokenIn, msg.sender, tokenAmountIn);
+
+        return tokenAmountIn;
+    }
+
+    function exitswapPoolAmountIn(address tokenOut, uint poolAmountIn, uint minAmountOut)
+        external
+        _logs_
+        _lock_
+        returns (uint tokenAmountOut)
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+
+        Record storage outRecord = _records[tokenOut];
+
+        tokenAmountOut = calcSingleOutGivenPoolIn(
+                            outRecord.balance,
+                            outRecord.denorm,
+                            _totalSupply,
+                            _totalWeight,
+                            poolAmountIn,
+                            _swapFee
+                        );
+
+        require(tokenAmountOut >= minAmountOut, "ERR_LIMIT_OUT");
+
+        require(tokenAmountOut <= bmul(_records[tokenOut].balance, MAX_OUT_RATIO), "ERR_MAX_OUT_RATIO");
+
+        outRecord.balance = bsub(outRecord.balance, tokenAmountOut);
+
+        uint exitFee = bmul(poolAmountIn, EXIT_FEE);
+
+        emit LOG_EXIT(msg.sender, tokenOut, tokenAmountOut);
+
+        _pullPoolShare(msg.sender, poolAmountIn);
+        _burnPoolShare(bsub(poolAmountIn, exitFee));
+        _pushPoolShare(_factory, exitFee);
+        _pushUnderlying(tokenOut, msg.sender, tokenAmountOut);
+
+        return tokenAmountOut;
+    }
+
+    function exitswapExternAmountOut(address tokenOut, uint tokenAmountOut, uint maxPoolAmountIn)
+        external
+        _logs_
+        _lock_
+        returns (uint poolAmountIn)
+    {
+        require(_finalized, "ERR_NOT_FINALIZED");
+        require(_records[tokenOut].bound, "ERR_NOT_BOUND");
+        require(tokenAmountOut <= bmul(_records[tokenOut].balance, MAX_OUT_RATIO), "ERR_MAX_OUT_RATIO");
+
+        Record storage outRecord = _records[tokenOut];
+
+        poolAmountIn = calcPoolInGivenSingleOut(
+                            outRecord.balance,
+                            outRecord.denorm,
+                            _totalSupply,
+                            _totalWeight,
+                            tokenAmountOut,
+                            _swapFee
+                        );
+
+        require(poolAmountIn != 0, "ERR_MATH_APPROX");
+        require(poolAmountIn <= maxPoolAmountIn, "ERR_LIMIT_IN");
+
+        outRecord.balance = bsub(outRecord.balance, tokenAmountOut);
+
+        uint exitFee = bmul(poolAmountIn, EXIT_FEE);
+
+        emit LOG_EXIT(msg.sender, tokenOut, tokenAmountOut);
+
+        _pullPoolShare(msg.sender, poolAmountIn);
+        _burnPoolShare(bsub(poolAmountIn, exitFee));
+        _pushPoolShare(_factory, exitFee);
+        _pushUnderlying(tokenOut, msg.sender, tokenAmountOut);
+
+        return poolAmountIn;
+    }
+
+
+    // ==
+    // 'Underlying' token-manipulation functions make external calls but are NOT locked
+    // You must `_lock_` or otherwise ensure reentry-safety
+
+    function _pullUnderlying(address erc20, address from, uint amount)
+        internal
+    {
+        bool xfer = IERC20(erc20).transferFrom(from, address(this), amount);
+        require(xfer, "ERR_ERC20_FALSE");
+    }
+
+    function _pushUnderlying(address erc20, address to, uint amount)
+        internal
+    {
+        bool xfer = IERC20(erc20).transfer(to, amount);
+        require(xfer, "ERR_ERC20_FALSE");
+    }
+
+    function _pullPoolShare(address from, uint amount)
+        internal
+    {
+        _pull(from, amount);
+    }
+
+    function _pushPoolShare(address to, uint amount)
+        internal
+    {
+        _push(to, amount);
+    }
+
+    function _mintPoolShare(uint amount)
+        internal
+    {
+        _mint(amount);
+    }
+
+    function _burnPoolShare(uint amount)
+        internal
+    {
+        _burn(amount);
+    }
+
+}

--- a/contracts/verify-bpool-impl/BToken.sol
+++ b/contracts/verify-bpool-impl/BToken.sol
@@ -1,0 +1,130 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "./BNum.sol";
+import "./IERC20.sol";
+import "./Initializable.sol";
+
+abstract contract BTokenBase is BNum {
+
+    mapping(address => uint)                   internal _balance;
+    mapping(address => mapping(address=>uint)) internal _allowance;
+    uint internal _totalSupply;
+
+    event Approval(address indexed src, address indexed dst, uint amt);
+    event Transfer(address indexed src, address indexed dst, uint amt);
+
+    function _mint(uint amt) internal {
+        _balance[address(this)] = badd(_balance[address(this)], amt);
+        _totalSupply = badd(_totalSupply, amt);
+        emit Transfer(address(0), address(this), amt);
+    }
+
+    function _burn(uint amt) internal {
+        require(_balance[address(this)] >= amt, "ERR_INSUFFICIENT_BAL");
+        _balance[address(this)] = bsub(_balance[address(this)], amt);
+        _totalSupply = bsub(_totalSupply, amt);
+        emit Transfer(address(this), address(0), amt);
+    }
+
+    function _move(address src, address dst, uint amt) internal {
+        require(_balance[src] >= amt, "ERR_INSUFFICIENT_BAL");
+        _balance[src] = bsub(_balance[src], amt);
+        _balance[dst] = badd(_balance[dst], amt);
+        emit Transfer(src, dst, amt);
+    }
+
+    function _push(address to, uint amt) internal {
+        _move(address(this), to, amt);
+    }
+
+    function _pull(address from, uint amt) internal {
+        _move(from, address(this), amt);
+    }
+}
+
+abstract contract BToken is Initializable, BTokenBase, IERC20 {
+    string  private _name;
+    string  private _symbol;
+    uint8   private _decimals;
+
+    function __BToken_init_unchained() internal initializer {
+        _name     = "Swarm Markets Pool Token";
+        _symbol   = "SPT";
+        _decimals = 18;
+    }
+
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() public view returns(uint8) {
+        return _decimals;
+    }
+
+    function allowance(address src, address dst) external override view returns (uint) {
+        return _allowance[src][dst];
+    }
+
+    function balanceOf(address whom) external override view returns (uint) {
+        return _balance[whom];
+    }
+
+    function totalSupply() public override view returns (uint) {
+        return _totalSupply;
+    }
+
+    function approve(address dst, uint amt) external override returns (bool) {
+        _allowance[msg.sender][dst] = amt;
+        emit Approval(msg.sender, dst, amt);
+        return true;
+    }
+
+    function increaseApproval(address dst, uint amt) external returns (bool) {
+        _allowance[msg.sender][dst] = badd(_allowance[msg.sender][dst], amt);
+        emit Approval(msg.sender, dst, _allowance[msg.sender][dst]);
+        return true;
+    }
+
+    function decreaseApproval(address dst, uint amt) external returns (bool) {
+        uint oldValue = _allowance[msg.sender][dst];
+        if (amt > oldValue) {
+            _allowance[msg.sender][dst] = 0;
+        } else {
+            _allowance[msg.sender][dst] = bsub(oldValue, amt);
+        }
+        emit Approval(msg.sender, dst, _allowance[msg.sender][dst]);
+        return true;
+    }
+
+    function transfer(address dst, uint amt) external override returns (bool) {
+        _move(msg.sender, dst, amt);
+        return true;
+    }
+
+    function transferFrom(address src, address dst, uint amt) external override returns (bool) {
+        require(msg.sender == src || amt <= _allowance[src][msg.sender], "ERR_BTOKEN_BAD_CALLER");
+        _move(src, dst, amt);
+        if (msg.sender != src && _allowance[src][msg.sender] != uint256(-1)) {
+            _allowance[src][msg.sender] = bsub(_allowance[src][msg.sender], amt);
+            emit Approval(msg.sender, dst, _allowance[src][msg.sender]);
+        }
+        return true;
+    }
+}

--- a/contracts/verify-bpool-impl/IERC20.sol
+++ b/contracts/verify-bpool-impl/IERC20.sol
@@ -1,0 +1,26 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+interface IERC20 {
+    function totalSupply() external view returns (uint);
+    function balanceOf(address whom) external view returns (uint);
+    function allowance(address src, address dst) external view returns (uint);
+
+    function approve(address dst, uint amt) external returns (bool);
+    function transfer(address dst, uint amt) external returns (bool);
+    function transferFrom(
+        address src, address dst, uint amt
+    ) external returns (bool);
+}

--- a/contracts/verify-bpool-impl/Initializable.sol
+++ b/contracts/verify-bpool-impl/Initializable.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+
+// solhint-disable-next-line compiler-version
+pragma solidity >=0.4.24 <0.8.0;
+
+import "./Address.sol";
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ *
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {UpgradeableProxy-constructor}.
+ *
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ */
+abstract contract Initializable {
+
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private _initializing;
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier initializer() {
+        require(_initializing || _isConstructor() || !_initialized, "Initializable: contract is already initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function _isConstructor() private view returns (bool) {
+        return !Address.isContract(address(this));
+    }
+}

--- a/contracts/verify-bpoolextend/ALL_IN_ONE.sol
+++ b/contracts/verify-bpoolextend/ALL_IN_ONE.sol
@@ -1,0 +1,535 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM
+ * instruction `delegatecall`. We refer to the second contract as the _implementation_ behind the proxy, and it has to
+ * be specified by overriding the virtual {_implementation} function.
+ *
+ * Additionally, delegation to the implementation can be triggered manually through the {_fallback} function, or to a
+ * different contract through the {_delegate} function.
+ *
+ * The success and return data of the delegated call will be returned back to the caller of the proxy.
+ */
+abstract contract Proxy {
+    /**
+     * @dev Delegates the current call to `implementation`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _delegate(address implementation) internal virtual {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    /**
+     * @dev This is a virtual function that should be overriden so it returns the address to which the fallback function
+     * and {_fallback} should delegate.
+     */
+    function _implementation() internal view virtual returns (address);
+
+    /**
+     * @dev Delegates the current call to the address returned by `_implementation()`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _fallback() internal virtual {
+        _beforeFallback();
+        _delegate(_implementation());
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if no other
+     * function in the contract matches the call data.
+     */
+    fallback () external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if call data
+     * is empty.
+     */
+    receive () external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Hook that is called before falling back to the implementation. Can happen as part of a manual `_fallback`
+     * call, or as part of the Solidity `fallback` or `receive` functions.
+     *
+     * If overriden should call `super._beforeFallback()`.
+     */
+    function _beforeFallback() internal virtual {
+    }
+}
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: value }(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data, string memory errorMessage) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    function _verifyCallResult(bool success, bytes memory returndata, string memory errorMessage) private pure returns(bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+/**
+ * @dev Interface of the ERC165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[EIP].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+
+/**
+ * @dev Implementation of the {IERC165} interface.
+ *
+ * Contracts may inherit from this and call {_registerInterface} to declare
+ * their support of an interface.
+ */
+abstract contract ERC165 is IERC165 {
+    /*
+     * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
+     */
+    bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
+
+    /**
+     * @dev Mapping of interface ids to whether or not it's supported.
+     */
+    mapping(bytes4 => bool) private _supportedInterfaces;
+
+    constructor () {
+        // Derived contracts need only register support for their own interfaces,
+        // we register support for ERC165 itself here
+        _registerInterface(_INTERFACE_ID_ERC165);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     *
+     * Time complexity O(1), guaranteed to always use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return _supportedInterfaces[interfaceId];
+    }
+
+    /**
+     * @dev Registers the contract as an implementer of the interface defined by
+     * `interfaceId`. Support of the actual ERC165 interface is automatic and
+     * registering its interface id is not required.
+     *
+     * See {IERC165-supportsInterface}.
+     *
+     * Requirements:
+     *
+     * - `interfaceId` cannot be the ERC165 invalid interface (`0xffffffff`).
+     */
+    function _registerInterface(bytes4 interfaceId) internal virtual {
+        require(interfaceId != 0xffffffff, "ERC165: invalid interface id");
+        _supportedInterfaces[interfaceId] = true;
+    }
+}
+
+/**
+ * _Available since v3.1._
+ */
+interface IERC1155Receiver is IERC165 {
+
+    /**
+        @dev Handles the receipt of a single ERC1155 token type. This function is
+        called at the end of a `safeTransferFrom` after the balance has been updated.
+        To accept the transfer, this must return
+        `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
+        (i.e. 0xf23a6e61, or its own function selector).
+        @param operator The address which initiated the transfer (i.e. msg.sender)
+        @param from The address which previously owned the token
+        @param id The ID of the token being transferred
+        @param value The amount of tokens being transferred
+        @param data Additional data with no specified format
+        @return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` if transfer is allowed
+    */
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+    )
+        external
+        returns(bytes4);
+
+    /**
+        @dev Handles the receipt of a multiple ERC1155 token types. This function
+        is called at the end of a `safeBatchTransferFrom` after the balances have
+        been updated. To accept the transfer(s), this must return
+        `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+        (i.e. 0xbc197c81, or its own function selector).
+        @param operator The address which initiated the batch transfer (i.e. msg.sender)
+        @param from The address which previously owned the token
+        @param ids An array containing ids of each token being transferred (order and length must match values array)
+        @param values An array containing amounts of each token being transferred (order and length must match ids array)
+        @param data Additional data with no specified format
+        @return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` if transfer is allowed
+    */
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    )
+        external
+        returns(bytes4);
+}
+
+
+/**
+ * @dev _Available since v3.1._
+ */
+abstract contract ERC1155Receiver is ERC165, IERC1155Receiver {
+    constructor() {
+        _registerInterface(
+            ERC1155Receiver(address(0)).onERC1155Received.selector ^
+            ERC1155Receiver(address(0)).onERC1155BatchReceived.selector
+        );
+    }
+}
+
+
+/**
+ * @dev _Available since v3.1._
+ */
+contract ERC1155Holder is ERC1155Receiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] memory, uint256[] memory, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155BatchReceived.selector;
+    }
+}
+
+
+
+interface IOperationsRegistry {
+    function allowedAssets(address asset) external view returns (bool);
+}
+
+interface IBPool {
+    function bind(
+        address token,
+        uint256 balance,
+        uint256 denorm
+    ) external;
+
+    function joinPool(uint256 poolAmountOut, uint256[] calldata maxAmountsIn) external;
+
+    function exitPool(uint256 poolAmountIn, uint256[] calldata minAmountsOut) external;
+
+    function swapExactAmountIn(
+        address tokenIn,
+        uint256 tokenAmountIn,
+        address tokenOut,
+        uint256 minAmountOut,
+        uint256 maxPrice
+    ) external returns (uint256 tokenAmountOut, uint256 spotPriceAfter);
+
+    function swapExactAmountOut(
+        address tokenIn,
+        uint256 maxAmountIn,
+        address tokenOut,
+        uint256 tokenAmountOut,
+        uint256 maxPrice
+    ) external returns (uint256 tokenAmountIn, uint256 spotPriceAfter);
+
+    function joinswapExternAmountIn(
+        address tokenIn,
+        uint256 tokenAmountIn,
+        uint256 minPoolAmountOut
+    ) external returns (uint256 poolAmountOut);
+
+    function joinswapPoolAmountOut(
+        address tokenIn,
+        uint256 poolAmountOut,
+        uint256 maxAmountIn
+    ) external returns (uint256 tokenAmountIn);
+
+    function exitswapPoolAmountIn(
+        address tokenOut,
+        uint256 poolAmountIn,
+        uint256 minAmountOut
+    ) external returns (uint256 tokenAmountOut);
+
+    function exitswapExternAmountOut(
+        address tokenOut,
+        uint256 tokenAmountOut,
+        uint256 maxPoolAmountIn
+    ) external returns (uint256 poolAmountIn);
+}
+
+contract BPoolExtend is Proxy, ERC1155Holder {
+    address public immutable implementation;
+    address public immutable exchangeProxy;
+    address public immutable operationsRegistry;
+
+    constructor(address _poolImpl, address _operationsRegistry, address _exchProxy, bytes memory _data) {
+        implementation = _poolImpl;
+        exchangeProxy = _exchProxy;
+        operationsRegistry = _operationsRegistry;
+
+        if(_data.length > 0) {
+            Address.functionDelegateCall(_poolImpl, _data);
+        }
+    }
+
+    function _implementation() internal view override returns (address) {
+        return implementation;
+    }
+
+    function _beforeFallback() internal view override {
+       _onlyExchangeProxy();
+       _onlyAllowedToken();
+    }
+
+    function _onlyExchangeProxy() internal view {
+        if (
+           msg.sig == IBPool.joinPool.selector ||
+           msg.sig == IBPool.exitPool.selector ||
+           msg.sig == IBPool.swapExactAmountIn.selector ||
+           msg.sig == IBPool.swapExactAmountOut.selector ||
+           msg.sig == IBPool.joinswapExternAmountIn.selector ||
+           msg.sig == IBPool.joinswapPoolAmountOut.selector ||
+           msg.sig == IBPool.exitswapPoolAmountIn.selector ||
+           msg.sig == IBPool.exitswapExternAmountOut.selector
+        ) {
+            require(msg.sender == exchangeProxy, "ERR_NOT_EXCHANGE_PROXY");
+       }
+    }
+
+    function _onlyAllowedToken() internal view {
+        if (msg.sig == IBPool.bind.selector) {
+            (address token, , ) = abi.decode(msg.data[4:], (address, address, uint256));
+            require(IOperationsRegistry(operationsRegistry).allowedAssets(token), "ERR_NOT_ALLOWED_TOKEN");
+        }
+    }
+}

--- a/contracts/verify-bpoolextend/Address.sol
+++ b/contracts/verify-bpoolextend/Address.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: value }(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data, string memory errorMessage) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    function _verifyCallResult(bool success, bytes memory returndata, string memory errorMessage) private pure returns(bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}

--- a/contracts/verify-bpoolextend/BPoolExtend.sol
+++ b/contracts/verify-bpoolextend/BPoolExtend.sol
@@ -1,0 +1,121 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "./Proxy.sol";
+import "./Address.sol";
+import "./ERC1155Holder.sol";
+
+interface IOperationsRegistry {
+    function allowedAssets(address asset) external view returns (bool);
+}
+
+interface IBPool {
+    function bind(
+        address token,
+        uint256 balance,
+        uint256 denorm
+    ) external;
+
+    function joinPool(uint256 poolAmountOut, uint256[] calldata maxAmountsIn) external;
+
+    function exitPool(uint256 poolAmountIn, uint256[] calldata minAmountsOut) external;
+
+    function swapExactAmountIn(
+        address tokenIn,
+        uint256 tokenAmountIn,
+        address tokenOut,
+        uint256 minAmountOut,
+        uint256 maxPrice
+    ) external returns (uint256 tokenAmountOut, uint256 spotPriceAfter);
+
+    function swapExactAmountOut(
+        address tokenIn,
+        uint256 maxAmountIn,
+        address tokenOut,
+        uint256 tokenAmountOut,
+        uint256 maxPrice
+    ) external returns (uint256 tokenAmountIn, uint256 spotPriceAfter);
+
+    function joinswapExternAmountIn(
+        address tokenIn,
+        uint256 tokenAmountIn,
+        uint256 minPoolAmountOut
+    ) external returns (uint256 poolAmountOut);
+
+    function joinswapPoolAmountOut(
+        address tokenIn,
+        uint256 poolAmountOut,
+        uint256 maxAmountIn
+    ) external returns (uint256 tokenAmountIn);
+
+    function exitswapPoolAmountIn(
+        address tokenOut,
+        uint256 poolAmountIn,
+        uint256 minAmountOut
+    ) external returns (uint256 tokenAmountOut);
+
+    function exitswapExternAmountOut(
+        address tokenOut,
+        uint256 tokenAmountOut,
+        uint256 maxPoolAmountIn
+    ) external returns (uint256 poolAmountIn);
+}
+
+contract BPoolExtend is Proxy, ERC1155Holder {
+    address public immutable implementation;
+    address public immutable exchangeProxy;
+    address public immutable operationsRegistry;
+
+    constructor(address _poolImpl, address _operationsRegistry, address _exchProxy, bytes memory _data) {
+        implementation = _poolImpl;
+        exchangeProxy = _exchProxy;
+        operationsRegistry = _operationsRegistry;
+
+        if(_data.length > 0) {
+            Address.functionDelegateCall(_poolImpl, _data);
+        }
+    }
+
+    function _implementation() internal view override returns (address) {
+        return implementation;
+    }
+
+    function _beforeFallback() internal view override {
+       _onlyExchangeProxy();
+       _onlyAllowedToken();
+    }
+
+    function _onlyExchangeProxy() internal view {
+        if (
+           msg.sig == IBPool.joinPool.selector ||
+           msg.sig == IBPool.exitPool.selector ||
+           msg.sig == IBPool.swapExactAmountIn.selector ||
+           msg.sig == IBPool.swapExactAmountOut.selector ||
+           msg.sig == IBPool.joinswapExternAmountIn.selector ||
+           msg.sig == IBPool.joinswapPoolAmountOut.selector ||
+           msg.sig == IBPool.exitswapPoolAmountIn.selector ||
+           msg.sig == IBPool.exitswapExternAmountOut.selector
+        ) {
+            require(msg.sender == exchangeProxy, "ERR_NOT_EXCHANGE_PROXY");
+       }
+    }
+
+    function _onlyAllowedToken() internal view {
+        if (msg.sig == IBPool.bind.selector) {
+            (address token, , ) = abi.decode(msg.data[4:], (address, address, uint256));
+            require(IOperationsRegistry(operationsRegistry).allowedAssets(token), "ERR_NOT_ALLOWED_TOKEN");
+        }
+    }
+}

--- a/contracts/verify-bpoolextend/ERC1155Holder.sol
+++ b/contracts/verify-bpoolextend/ERC1155Holder.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "./ERC1155Receiver.sol";
+
+/**
+ * @dev _Available since v3.1._
+ */
+contract ERC1155Holder is ERC1155Receiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] memory, uint256[] memory, bytes memory) public virtual override returns (bytes4) {
+        return this.onERC1155BatchReceived.selector;
+    }
+}

--- a/contracts/verify-bpoolextend/ERC1155Receiver.sol
+++ b/contracts/verify-bpoolextend/ERC1155Receiver.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "./IERC1155Receiver.sol";
+import "./ERC165.sol";
+
+/**
+ * @dev _Available since v3.1._
+ */
+abstract contract ERC1155Receiver is ERC165, IERC1155Receiver {
+    constructor() {
+        _registerInterface(
+            ERC1155Receiver(address(0)).onERC1155Received.selector ^
+            ERC1155Receiver(address(0)).onERC1155BatchReceived.selector
+        );
+    }
+}

--- a/contracts/verify-bpoolextend/ERC165.sol
+++ b/contracts/verify-bpoolextend/ERC165.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "./IERC165.sol";
+
+/**
+ * @dev Implementation of the {IERC165} interface.
+ *
+ * Contracts may inherit from this and call {_registerInterface} to declare
+ * their support of an interface.
+ */
+abstract contract ERC165 is IERC165 {
+    /*
+     * bytes4(keccak256('supportsInterface(bytes4)')) == 0x01ffc9a7
+     */
+    bytes4 private constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
+
+    /**
+     * @dev Mapping of interface ids to whether or not it's supported.
+     */
+    mapping(bytes4 => bool) private _supportedInterfaces;
+
+    constructor () {
+        // Derived contracts need only register support for their own interfaces,
+        // we register support for ERC165 itself here
+        _registerInterface(_INTERFACE_ID_ERC165);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     *
+     * Time complexity O(1), guaranteed to always use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return _supportedInterfaces[interfaceId];
+    }
+
+    /**
+     * @dev Registers the contract as an implementer of the interface defined by
+     * `interfaceId`. Support of the actual ERC165 interface is automatic and
+     * registering its interface id is not required.
+     *
+     * See {IERC165-supportsInterface}.
+     *
+     * Requirements:
+     *
+     * - `interfaceId` cannot be the ERC165 invalid interface (`0xffffffff`).
+     */
+    function _registerInterface(bytes4 interfaceId) internal virtual {
+        require(interfaceId != 0xffffffff, "ERC165: invalid interface id");
+        _supportedInterfaces[interfaceId] = true;
+    }
+}

--- a/contracts/verify-bpoolextend/IERC1155Receiver.sol
+++ b/contracts/verify-bpoolextend/IERC1155Receiver.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "./IERC165.sol";
+
+/**
+ * _Available since v3.1._
+ */
+interface IERC1155Receiver is IERC165 {
+
+    /**
+        @dev Handles the receipt of a single ERC1155 token type. This function is
+        called at the end of a `safeTransferFrom` after the balance has been updated.
+        To accept the transfer, this must return
+        `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
+        (i.e. 0xf23a6e61, or its own function selector).
+        @param operator The address which initiated the transfer (i.e. msg.sender)
+        @param from The address which previously owned the token
+        @param id The ID of the token being transferred
+        @param value The amount of tokens being transferred
+        @param data Additional data with no specified format
+        @return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` if transfer is allowed
+    */
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+    )
+        external
+        returns(bytes4);
+
+    /**
+        @dev Handles the receipt of a multiple ERC1155 token types. This function
+        is called at the end of a `safeBatchTransferFrom` after the balances have
+        been updated. To accept the transfer(s), this must return
+        `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+        (i.e. 0xbc197c81, or its own function selector).
+        @param operator The address which initiated the batch transfer (i.e. msg.sender)
+        @param from The address which previously owned the token
+        @param ids An array containing ids of each token being transferred (order and length must match values array)
+        @param values An array containing amounts of each token being transferred (order and length must match ids array)
+        @param data Additional data with no specified format
+        @return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` if transfer is allowed
+    */
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    )
+        external
+        returns(bytes4);
+}

--- a/contracts/verify-bpoolextend/IERC165.sol
+++ b/contracts/verify-bpoolextend/IERC165.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev Interface of the ERC165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[EIP].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}

--- a/contracts/verify-bpoolextend/Proxy.sol
+++ b/contracts/verify-bpoolextend/Proxy.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM
+ * instruction `delegatecall`. We refer to the second contract as the _implementation_ behind the proxy, and it has to
+ * be specified by overriding the virtual {_implementation} function.
+ *
+ * Additionally, delegation to the implementation can be triggered manually through the {_fallback} function, or to a
+ * different contract through the {_delegate} function.
+ *
+ * The success and return data of the delegated call will be returned back to the caller of the proxy.
+ */
+abstract contract Proxy {
+    /**
+     * @dev Delegates the current call to `implementation`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _delegate(address implementation) internal virtual {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    /**
+     * @dev This is a virtual function that should be overriden so it returns the address to which the fallback function
+     * and {_fallback} should delegate.
+     */
+    function _implementation() internal view virtual returns (address);
+
+    /**
+     * @dev Delegates the current call to the address returned by `_implementation()`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _fallback() internal virtual {
+        _beforeFallback();
+        _delegate(_implementation());
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if no other
+     * function in the contract matches the call data.
+     */
+    fallback () external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if call data
+     * is empty.
+     */
+    receive () external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Hook that is called before falling back to the implementation. Can happen as part of a manual `_fallback`
+     * call, or as part of the Solidity `fallback` or `receive` functions.
+     *
+     * If overriden should call `super._beforeFallback()`.
+     */
+    function _beforeFallback() internal virtual {
+    }
+}


### PR DESCRIPTION
As a summary of the situation, Polygon and Mumbai contracts could not be verified because the source code uploaded was unknown. I did some research across git history in the different repos involved and I managed to verify the `BFactory` and `BPool` contracts on Mumbai and Polygon.

I'm committing the code here for posterity. Each verification has its own subfolder in the `/contracts` folder. I verified via the multipart option when possible and inlined all the contracts in the `ALL_IN_ONE` files when not possible. For example, some contracts on Polygon could be verified via multipart meanwhile the same contract on Mumbai could not.

I'm not expecting this to be merged, it's only for discoverability. Swarm will consider in the upcoming months what to do about the state of these contracts and a potential redeploy to extend them.